### PR TITLE
Add macOS .app launcher (native, no Docker)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 
 # Runtime / temp
 .staging/
+server/*.pid
 *.mp3
 test_output*.mp3
 server/*.log

--- a/JAVIS OS.app/Contents/Info.plist
+++ b/JAVIS OS.app/Contents/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>JAVIS OS</string>
+    <key>CFBundleDisplayName</key>
+    <string>JAVIS OS</string>
+    <key>CFBundleIdentifier</key>
+    <string>vn.minhquy.javis-os</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleExecutable</key>
+    <string>javis</string>
+    <key>CFBundleIconFile</key>
+    <string>javis</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>11.0</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>

--- a/JAVIS OS.app/Contents/MacOS/javis
+++ b/JAVIS OS.app/Contents/MacOS/javis
@@ -1,0 +1,6 @@
+#!/bin/bash
+# App bundle entrypoint -> delegates to bin/javis-start.sh.
+# Resolves the repo root relative to this bundle, so keep "JAVIS OS.app"
+# inside the repo folder (repo/JAVIS OS.app/Contents/MacOS/javis).
+DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+exec "${DIR}/bin/javis-start.sh"

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ chmod +x install.sh && ./install.sh
 ```
 Script tự cài Python + Node + Claude CLI, tạo venv, đăng ký dịch vụ systemd tự chạy khi boot, in ra địa chỉ. Báo Claude chưa đăng nhập thì chạy 1 lần: `claude auth login --claudeai`.
 
+> 🍎 **macOS - mở như một app:** sau khi cài xong, double-click `JAVIS OS.app` (hoặc `Start JAVIS OS.command`) để chạy server + mở dashboard; tự chạy khi đăng nhập máy: `./bin/javis-autostart.sh install`. Chi tiết: [bin/README.md](bin/README.md).
+
 ### Cách 4 - Windows (máy cá nhân)
 
 ```

--- a/Start JAVIS OS.command
+++ b/Start JAVIS OS.command
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Double-click in Finder to start JAVIS OS and open the dashboard.
+cd "$(dirname "$0")" || exit 1
+bash "bin/javis-start.sh"
+echo ""
+echo "JAVIS OS is running at http://127.0.0.1:7777"
+echo "This window can be closed - the server keeps running in the background."

--- a/Stop JAVIS OS.command
+++ b/Stop JAVIS OS.command
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Double-click in Finder to stop JAVIS OS.
+cd "$(dirname "$0")" || exit 1
+bash "bin/javis-stop.sh"
+echo ""
+echo "You can close this window."

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,34 @@
+# JAVIS OS - macOS launchers
+
+Portable helpers to run JAVIS OS natively on macOS (no Docker), so you can
+start it like a normal app.
+
+## Prereqs (once)
+
+1. From the repo root: `./install.sh` - creates `.venv`, installs deps and the
+   Claude Code CLI. (On Apple Silicon without Homebrew you can create the
+   environment with [uv](https://docs.astral.sh/uv/): `uv venv --python 3.12 .venv`
+   then `uv pip install -r requirements.txt`, and install the CLI with
+   `npm install -g @anthropic-ai/claude-code`.)
+2. Log in to the brain once: `claude auth login --claudeai`.
+
+## Run
+
+- **`JAVIS OS.app`** (repo root) - double-click in Finder to start the server and
+  open `http://127.0.0.1:7777`. Keep the `.app` inside the repo folder (it finds
+  the repo relative to its own location).
+- **`Start JAVIS OS.command`** / **`Stop JAVIS OS.command`** - double-clickable
+  Finder alternatives.
+- **`bin/javis-start.sh`** / **`bin/javis-stop.sh`** - the underlying scripts.
+- **`bin/javis-autostart.sh [install|uninstall]`** - run the server at login via a
+  macOS LaunchAgent. The plist is generated with paths for your machine; nothing
+  is hardcoded in the repo.
+
+## Notes
+
+- Every script resolves the repo location from its own path, so the repo can live
+  anywhere.
+- Default port is `7777`; override with the `JAVIS_PORT` environment variable.
+- Bound to `127.0.0.1` (local only). Because it's `localhost`, the browser allows
+  the microphone, so voice works without HTTPS. Use Chrome or Edge for speech
+  recognition.

--- a/bin/javis-autostart.sh
+++ b/bin/javis-autostart.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# ============================================================
+# JAVIS OS - macOS auto-start (LaunchAgent) installer
+#   ./bin/javis-autostart.sh install     # start at login (default)
+#   ./bin/javis-autostart.sh uninstall    # remove
+#
+# Generates ~/Library/LaunchAgents/vn.minhquy.javis-os.plist with paths
+# computed for THIS machine (nothing hardcoded in the repo).
+# ============================================================
+set -u
+
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LABEL="vn.minhquy.javis-os"
+PLIST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+PORT="${JAVIS_PORT:-7777}"
+PY="${APP_DIR}/.venv/bin/python"
+ACTION="${1:-install}"
+
+if [ "${ACTION}" = "uninstall" ]; then
+  launchctl unload "${PLIST}" 2>/dev/null || true
+  rm -f "${PLIST}"
+  echo "JAVIS OS auto-start removed."
+  exit 0
+fi
+
+if [ ! -x "${PY}" ]; then
+  echo "Missing venv at ${PY} - run ./install.sh first." >&2
+  exit 1
+fi
+
+# Build a PATH that includes the npm global bin (where `claude` lives)
+NPM_BIN=""
+command -v npm >/dev/null 2>&1 && NPM_BIN="$(npm prefix -g 2>/dev/null)/bin"
+PATH_STR="${NPM_BIN}:${HOME}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+mkdir -p "${HOME}/Library/LaunchAgents"
+cat > "${PLIST}" <<PLISTEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>${LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${PY}</string>
+        <string>-m</string><string>uvicorn</string><string>main:app</string>
+        <string>--host</string><string>127.0.0.1</string>
+        <string>--port</string><string>${PORT}</string>
+    </array>
+    <key>WorkingDirectory</key><string>${APP_DIR}/server</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>JAVIS_STATE_DIR</key><string>${APP_DIR}/server</string>
+        <key>PATH</key><string>${PATH_STR}</string>
+    </dict>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+    <key>StandardOutPath</key><string>${APP_DIR}/server/javis.log</string>
+    <key>StandardErrorPath</key><string>${APP_DIR}/server/javis.log</string>
+</dict>
+</plist>
+PLISTEOF
+
+launchctl unload "${PLIST}" 2>/dev/null || true
+launchctl load "${PLIST}"
+echo "JAVIS OS auto-start installed -> http://127.0.0.1:${PORT}"
+echo "Remove with: ./bin/javis-autostart.sh uninstall"

--- a/bin/javis-start.sh
+++ b/bin/javis-start.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# ============================================================
+# JAVIS OS - macOS launcher (start)
+# Starts the FastAPI server (if not already running) and opens
+# the dashboard in the default browser. No Docker required.
+#
+# Paths are resolved from this script's own location, so the repo
+# can live anywhere. Run ./install.sh once first to create .venv.
+# ============================================================
+set -u
+
+# Repo root = parent of this script's directory (bin/)
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT="${JAVIS_PORT:-7777}"
+URL="http://127.0.0.1:${PORT}"
+LOG="${APP_DIR}/server/javis.log"
+PIDF="${APP_DIR}/server/javis.pid"
+PY="${APP_DIR}/.venv/bin/python"
+
+# A GUI (Finder/LaunchServices) launch starts with a minimal PATH, so add the
+# common CLI locations - the server subprocess needs to find `claude` (the
+# brain), plus node/ffmpeg/rg.
+export PATH="${HOME}/.local/bin:/opt/homebrew/bin:/usr/local/bin:${PATH}"
+if command -v npm >/dev/null 2>&1; then
+  NPM_BIN="$(npm prefix -g 2>/dev/null)/bin"
+  [ -d "${NPM_BIN}" ] && export PATH="${NPM_BIN}:${PATH}"
+fi
+
+# Already up? Just open it.
+if curl -sf -o /dev/null "${URL}/" 2>/dev/null; then
+  open "${URL}"
+  exit 0
+fi
+
+if [ ! -x "${PY}" ]; then
+  osascript -e 'display alert "JAVIS OS" message "Chua cai moi truong. Chay ./install.sh trong thu muc du an truoc."' 2>/dev/null || true
+  echo "Missing venv at ${PY} - run ./install.sh first." >&2
+  exit 1
+fi
+
+cd "${APP_DIR}/server" || exit 1
+JAVIS_STATE_DIR="${APP_DIR}/server" nohup "${PY}" \
+  -m uvicorn main:app --host 127.0.0.1 --port "${PORT}" > "${LOG}" 2>&1 &
+echo $! > "${PIDF}"
+
+# Wait until healthy (max ~30s), then open the browser
+for _ in $(seq 1 30); do
+  sleep 1
+  if curl -sf -o /dev/null "${URL}/" 2>/dev/null; then break; fi
+done
+open "${URL}"

--- a/bin/javis-stop.sh
+++ b/bin/javis-stop.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# ============================================================
+# JAVIS OS - macOS launcher (stop)
+# ============================================================
+set -u
+
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PIDF="${APP_DIR}/server/javis.pid"
+PORT="${JAVIS_PORT:-7777}"
+
+if [ -f "${PIDF}" ]; then
+  kill "$(cat "${PIDF}")" 2>/dev/null
+  rm -f "${PIDF}"
+fi
+# Fallback: kill whatever holds the port
+lsof -ti "tcp:${PORT}" 2>/dev/null | xargs kill 2>/dev/null || true
+echo "JAVIS OS stopped."


### PR DESCRIPTION
## Tóm tắt

Thêm cách chạy JAVIS OS **như một app trên macOS** (không cần Docker), bổ sung cho `install.sh`. Sau khi cài xong, người dùng chỉ cần **double-click `JAVIS OS.app`** để khởi động server và mở dashboard.

Repo đã có launcher cho Windows (`start-javis.bat`, `start-javis.vbs`...) và `install.sh` cho Linux/macOS, nhưng chưa có kiểu "mở như một app" cho macOS. PR này lấp chỗ đó.

## Có gì mới

- **`JAVIS OS.app`** - bundle double-click trong Finder: chạy server (nếu chưa chạy) rồi mở `http://127.0.0.1:7777`.
- **`Start JAVIS OS.command` / `Stop JAVIS OS.command`** - bản double-click thay thế.
- **`bin/javis-start.sh` / `bin/javis-stop.sh`** - script nền (khởi động + mở dashboard; dừng theo PID, fallback theo port).
- **`bin/javis-autostart.sh [install|uninstall]`** - tạo/gỡ LaunchAgent để tự chạy khi đăng nhập máy. Plist được **sinh theo máy**, không hardcode đường dẫn trong repo.
- **`bin/README.md`** - hướng dẫn ngắn; thêm 1 dòng trỏ tới nó ở mục "Cách 3 - macOS" trong `README.md`.
- `.gitignore`: bỏ qua `server/*.pid` (file runtime).

## Thiết kế

- **Không hardcode đường dẫn:** mọi script tự suy ra vị trí repo từ vị trí của chính nó (`.app` suy từ vị trí bundle), nên repo đặt ở đâu cũng chạy.
- **Cổng:** mặc định `7777`, đổi bằng biến môi trường `JAVIS_PORT`.
- **Tìm được `claude`:** launch từ Finder có PATH tối thiểu, nên script tự thêm `~/.local/bin`, Homebrew, và npm global bin (`npm prefix -g`) vào PATH để server tìm thấy Claude CLI.
- **Bind `127.0.0.1`:** vì là localhost nên trình duyệt cho phép micro → giọng nói chạy được mà không cần HTTPS.

## Đã test

Trên macOS (Apple Silicon, Python 3.12, Node 20):
- `bin/javis-start.sh` → server lên, `GET /` trả **HTTP 200** trong ~2s, mở dashboard.
- `bin/javis-stop.sh` → dừng sạch (theo PID, fallback theo port).
- Xác nhận không còn đường dẫn tuyệt đối của máy cá nhân trong bất kỳ file nào.

## Lưu ý cho reviewer

- Prereq vẫn là chạy `./install.sh` một lần (tạo `.venv`, cài Claude CLI) rồi `claude auth login --claudeai`. PR này chỉ thêm launcher, không đụng luồng cài đặt.
- Giữ `JAVIS OS.app` trong thư mục repo (nó dò repo theo vị trí bundle). Muốn cho phép chuyển vào `/Applications` thì có thể mở rộng sau (đọc đường dẫn từ file config).
- `Info.plist` đặt `LSUIElement=true` để không hiện icon Dock (chạy nền, điều khiển qua trình duyệt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
