### PR TITLE
Adaptive Runtime v2 Phase 10: workflow chạy qua capability graph có checkpoint

### DIFF
--- a/docs/dev/2026-08-adaptive-context-runtime-spec.md
+++ b/docs/dev/2026-08-adaptive-context-runtime-spec.md
@@ -1894,6 +1894,28 @@ Rollback: tắt task write mới của capability group. Không rollback task đ
 
 ### Phase 10: Workflow capability graph
 
+Trạng thái code ngày 2026-08-02: **hoàn tất, chưa bật production**. `workflow_canary` mặc định
+allocation `0` và `allowed_slugs` rỗng (fail-closed), nên mọi workflow tiếp tục chạy bằng runner
+cũ. Đường mới dùng CHUNG engine, prompt và bộ event với runner cũ; khác biệt duy nhất là nó có
+trạng thái.
+
+Ba bất biến đã có test canh, mỗi cái được kiểm chứng bằng cách gỡ hàng rào ra xem test có đỏ:
+
+- **Node đã xong không chạy lại.** Resume đọc checkpoint; node `COMPLETED` giữ nguyên output.
+- **Node ghi không bao giờ tự chạy.** Workflow nền không có ai để hỏi, nên gặp node ghi là dừng
+  ở `WAITING_USER`. Xác nhận sai node thì vẫn đứng yên.
+- **Workflow con ghim theo revision.** Thiếu revision là từ chối biên dịch; revision lệch là node
+  hỏng, không chạy nhầm bản mới.
+
+Câu hỏi mục 30.3 ý 5 đã có câu trả lời: workflow hiện tại **không có hợp đồng dữ liệu nào cả**
+(bốn trường mỗi bước, truyền dữ liệu bằng thay chuỗi `{{prev}}`, chỉ output bước cuối quan sát
+được). Vì vậy adapter phải **tự suy ra** hợp đồng chứ không đọc được từ file, và hợp đồng suy ra
+được đánh dấu `derived: true`. Làm output giàu hơn "chuỗi của bước cuối" là ĐỔI HÀNH VI, không
+phải di trú - để lại cho một thay đổi riêng có canary riêng.
+
+Ngoài phạm vi phase này: node `capability` và `workflow_call` mới được validate và checkpoint,
+chưa được tự thực thi; đường graph hiện chỉ tự chạy `model_step`.
+
 Thay đổi:
 
 - WorkflowSource và WorkflowManifest.

--- a/server/capability_registry.py
+++ b/server/capability_registry.py
@@ -359,6 +359,45 @@ class CapabilityRegistry:
             "revision": self.revision(brain),
         }
 
+    def refresh_workflows(self, brain: str | Path, manifests: Iterable[dict]) -> dict:
+        """Refresh a derived WorkflowSource: metadata + hợp đồng, KHÔNG kèm thân node.
+
+        Workflow vào Registry với kind `workflow`. Resolver hard-filter kind này khỏi
+        đường chọn tool y như `skill`, nên thêm workflow không làm prompt đầu nạp to ra.
+        """
+        scope = brain_scope(brain)
+        source_key = f"{scope}:workflow:brain-workflows"
+        records = []
+        for manifest in manifests or []:
+            if not isinstance(manifest, dict):
+                continue
+            slug = str(manifest.get("slug") or "").strip()
+            if not slug:
+                continue
+            name = str(manifest.get("name") or slug).strip()[:180]
+            summary = str(manifest.get("description") or name).strip()[:2000]
+            aliases = list(dict.fromkeys([slug, name]))
+            payload = {
+                "slug": slug, "name": name, "summary": summary,
+                "revision": str(manifest.get("revision") or "")[:128],
+                "adapter": str(manifest.get("adapter") or "")[:60],
+                "node_count": int(manifest.get("node_count") or 0),
+                "max_risk": str(manifest.get("max_risk") or "none")[:20],
+                "resumable": bool(manifest.get("resumable")),
+                "has_write_node": bool(manifest.get("has_write_node")),
+                "nested_slugs": list(manifest.get("nested_slugs") or []),
+                "input_contract": manifest.get("input_contract") or {},
+                "output_contract": manifest.get("output_contract") or {},
+                "path": str(manifest.get("relative_path") or "")[:500],
+            }
+            records.append({
+                "capability_id": "workflow_" + _sha(source_key + "|" + slug)[:24],
+                "name": slug, "aliases": aliases, "summary": summary,
+                "intent": " ".join(_WORD_RE.findall((name + " " + summary).casefold())[:80]),
+                "revision": _sha(payload), "metadata": payload,
+            })
+        return self._refresh_derived_kind(brain, scope, source_key, "workflow", records)
+
     def refresh_skills(self, brain: str | Path, manifests: Iterable[dict]) -> dict:
         """Refresh a derived SkillSource using metadata/path only, never SKILL.md bodies."""
         scope = brain_scope(brain)
@@ -385,6 +424,15 @@ class CapabilityRegistry:
                 "intent": " ".join(_WORD_RE.findall((name + " " + summary + " " + group).casefold())[:80]),
                 "revision": _sha(payload), "metadata": payload,
             })
+        return self._refresh_derived_kind(brain, scope, source_key, "skill", records)
+
+    def _refresh_derived_kind(self, brain: str | Path, scope: str, source_key: str,
+                              kind: str, records: list[dict]) -> dict:
+        """Thân chung cho các source DẪN XUẤT chỉ có metadata (skill, workflow).
+
+        Chúng không phải tool: schema rỗng, effect `read`, và Resolver hard-filter
+        theo kind nên chúng không bao giờ lọt vào danh sách tool gửi model.
+        """
         records.sort(key=lambda x: x["name"])
         source_hash = _sha([{"name": x["name"], "revision": x["revision"]} for x in records])
         now = time.time()
@@ -400,22 +448,25 @@ class CapabilityRegistry:
                     "ON CONFLICT(source_key) DO UPDATE SET source_hash=excluded.source_hash,"
                     "revision=excluded.revision,health='healthy',capability_count=excluded.capability_count,"
                     "active=1,last_seen_at=excluded.last_seen_at,updated_at=excluded.updated_at",
-                    (source_key, scope, "skill", _sha(source_key)[:24], source_hash,
+                    (source_key, scope, kind, _sha(source_key)[:24], source_hash,
                      source_hash[:24], "healthy", len(records), 1, now, now),
                 )
                 if changed:
                     old_ids = [r[0] for r in db.execute(
                         "SELECT capability_id FROM capabilities WHERE source_key=?", (source_key,)
                     )]
-                    if self._fts:
-                        for capability_id in old_ids:
-                            db.execute("DELETE FROM capabilities_fts WHERE capability_id=?", (capability_id,))
+                    if self._fts and old_ids:
+                        placeholders = ",".join("?" for _ in old_ids)
+                        db.execute(
+                            f"DELETE FROM capabilities_fts WHERE capability_id IN ({placeholders})",
+                            old_ids,
+                        )
                     db.execute("DELETE FROM capabilities WHERE source_key=?", (source_key,))
                     empty_schema = {"type": "object", "properties": {}}
                     for item in records:
                         db.execute(
                             "INSERT INTO capabilities VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-                            (item["capability_id"], source_key, scope, "skill", item["name"],
+                            (item["capability_id"], source_key, scope, kind, item["name"],
                              _json(item["aliases"]), item["summary"], item["intent"], _json(empty_schema),
                              _sha(empty_schema), item["revision"], "read", "readonly", "healthy", 1,
                              _json(item["metadata"]), now),
@@ -426,7 +477,7 @@ class CapabilityRegistry:
                                 (item["capability_id"], item["name"], " ".join(item["aliases"]),
                                  item["summary"], item["intent"]),
                             )
-                self._set_meta(db, f"last_refresh_skills:{scope}", str(now))
+                self._set_meta(db, f"last_refresh_{kind}:{scope}", str(now))
                 self._revision_cache.pop(scope, None)
         return {"brain_scope": scope, "capability_count": len(records),
                 "changed_sources": int(changed), "revision": self.revision(brain)}

--- a/server/config.py
+++ b/server/config.py
@@ -187,6 +187,20 @@ _DEFAULT = {
             # Danh sách rỗng luôn fail-closed. Mỗi group có thể giới hạn args/TTL/timeout riêng.
             "capability_profiles": [],
         },
+        # Phase 10: workflow chạy qua đồ thị có checkpoint thay vì vòng lặp không trạng thái.
+        # Danh sách slug rỗng = fail-closed. Node ghi LUÔN dừng hỏi người dùng, cờ dưới
+        # chỉ quyết định workflow CÓ node ghi được chạy tới chỗ hỏi hay bị chặn từ đầu.
+        "workflow_canary": {
+            "policy_version": "workflow-graph-canary-v1",
+            "allocation_basis_points": 0,
+            "salt": "workflow-graph-canary-v1",
+            "allowed_slugs": [],
+            "max_nodes": 24,
+            "max_parallel": 3,
+            "node_timeout_seconds": 300,
+            "max_nesting_depth": 1,
+            "allow_write_nodes": False,
+        },
         # Phase 8 dùng hard quota operator khai báo; không đoán TPM/context theo tên model.
         # Có thể để trống để dùng quota_profiles của Fast Path ở trên.
         "context_sources": {"quota_profiles": []},

--- a/server/context_runtime.py
+++ b/server/context_runtime.py
@@ -69,6 +69,11 @@ def current_trace() -> Optional[TurnTrace]:
     return _CURRENT.get()
 
 
+# Đường chạy có checkpoint encrypted append-only. Phase 7 (orchestrator read-only) và
+# Phase 10 (workflow graph) dùng CHUNG cỗ máy này, không đẻ bảng riêng.
+CHECKPOINTED_PATHS = frozenset({"orchestrator", "workflow"})
+
+
 def bind_trace(trace: Optional[TurnTrace]):
     return _CURRENT.set(trace)
 
@@ -620,7 +625,8 @@ class ObserveRuntime:
         """Pin đường chạy đúng một lần cho task; đổi config giữa lượt không đổi task đang chạy."""
         if not trace:
             return "legacy"
-        requested = path if path in {"fast", "readonly", "orchestrator", "write"} else "legacy"
+        requested = path if path in {
+            "fast", "readonly", "orchestrator", "write", "workflow"} else "legacy"
         try:
             with self._lock:
                 db = self._conn()
@@ -712,7 +718,7 @@ class ObserveRuntime:
                                 state_hash: str, orchestration_status: str,
                                 budget: dict, deadline_at: float | None) -> bool:
         """Ghim state Phase 7 và checkpoint đầu tiên bằng cùng một transaction OCC."""
-        if (not trace or trace.execution_path != "orchestrator" or
+        if (not trace or trace.execution_path not in CHECKPOINTED_PATHS or
                 not str(objective_encrypted).startswith("enc:") or
                 not str(state_encrypted).startswith("enc:")):
             return False
@@ -728,7 +734,7 @@ class ObserveRuntime:
                         "active_state_encrypted=?,orchestration_status=?,budget_json=?,"
                         "deadline_at=?,version=version+1,updated_at=? "
                         "WHERE id=? AND version=? AND status='RUNNING' "
-                        "AND execution_path='orchestrator'",
+                        "AND execution_path IN ('orchestrator','workflow')",
                         (str(actor_hash or "")[:128], objective_encrypted,
                          state_encrypted, safe_status,
                          json.dumps(safe_budget, ensure_ascii=False, sort_keys=True,
@@ -762,7 +768,7 @@ class ObserveRuntime:
     def checkpoint_orchestrator(self, trace: Optional[TurnTrace], state_encrypted: str,
                                 state_hash: str, orchestration_status: str) -> bool:
         """Checkpoint encrypted, append-only; task row và version đổi atomically."""
-        if (not trace or trace.execution_path != "orchestrator" or
+        if (not trace or trace.execution_path not in CHECKPOINTED_PATHS or
                 not str(state_encrypted).startswith("enc:")):
             return False
         now = time.time()
@@ -780,7 +786,7 @@ class ObserveRuntime:
                         "UPDATE runtime_tasks SET active_state_encrypted=?,"
                         "orchestration_status=?,version=version+1,updated_at=? "
                         "WHERE id=? AND version=? AND status='RUNNING' "
-                        "AND execution_path='orchestrator'",
+                        "AND execution_path IN ('orchestrator','workflow')",
                         (state_encrypted, safe_status, now, trace.task_id,
                          trace.expected_version),
                     )
@@ -814,7 +820,8 @@ class ObserveRuntime:
             with self._lock:
                 db = self._conn()
                 task = db.execute(
-                    "SELECT * FROM runtime_tasks WHERE id=? AND execution_path='orchestrator'",
+                    "SELECT * FROM runtime_tasks WHERE id=? "
+                    "AND execution_path IN ('orchestrator','workflow')",
                     (str(task_id),),
                 ).fetchone()
                 checkpoint = db.execute(
@@ -861,7 +868,7 @@ class ObserveRuntime:
 
     def claim_orchestrator_resume(self, trace: Optional[TurnTrace]) -> bool:
         """OCC claim chống hai worker cùng resume một task trong cùng thời điểm."""
-        if not trace or trace.execution_path != "orchestrator":
+        if not trace or trace.execution_path not in CHECKPOINTED_PATHS:
             return False
         try:
             with self._lock:
@@ -870,7 +877,8 @@ class ObserveRuntime:
                     changed = db.execute(
                         "UPDATE runtime_tasks SET orchestration_status='RESUMING',"
                         "version=version+1,updated_at=? WHERE id=? AND version=? "
-                        "AND status='RUNNING' AND execution_path='orchestrator'",
+                        "AND status='RUNNING' "
+                        "AND execution_path IN ('orchestrator','workflow')",
                         (time.time(), trace.task_id, trace.expected_version),
                     )
                     if changed.rowcount != 1:
@@ -890,7 +898,7 @@ class ObserveRuntime:
                           objective_hash: str, attempt: int = 1,
                           parent_step_id: str | None = None) -> Optional[TurnTrace]:
         """Tạo step con độc lập; parallel step không tranh optimistic version của task."""
-        if not trace or trace.execution_path != "orchestrator":
+        if not trace or trace.execution_path not in CHECKPOINTED_PATHS:
             return None
         step_id = "rs_" + uuid.uuid4().hex
         now = time.time()
@@ -930,7 +938,7 @@ class ObserveRuntime:
 
     def finish_child_step(self, trace: Optional[TurnTrace], status: str,
                           error_code: str = "") -> bool:
-        if not trace or trace.execution_path != "orchestrator":
+        if not trace or trace.execution_path not in CHECKPOINTED_PATHS:
             return False
         safe = status if status in {
             "COMPLETED", "FAILED", "TIMEOUT", "SKIPPED", "CANCELLED"

--- a/server/main.py
+++ b/server/main.py
@@ -4156,18 +4156,17 @@ def workflows_index(brain: str) -> list:
                     "steps": meta.get("steps", []) or []})
     return out
 
-_WORKFLOW_CANARY = None
-
-
 def _get_workflow_canary(brain):
-    """Khởi tạo lười; mặc định allocation 0 nên production không trả chi phí gì."""
-    global _WORKFLOW_CANARY
-    if _WORKFLOW_CANARY is None:
-        _WORKFLOW_CANARY = workflow_runtime.WorkflowCanary(
-            _CONTEXT_RUNTIME, cfgmod.read_settings,
-            graph_loader=lambda slug: load_workflow_graph(brain, slug),
-        )
-    return _WORKFLOW_CANARY
+    """Dựng mới theo TỪNG brain.
+
+    KHÔNG được cache toàn cục: graph_loader đóng gói `brain`, nên một instance dùng
+    chung sẽ nạp workflow con của brain khác - đúng kiểu rò rỉ xuyên brain mà spec
+    bắt phải chặn. Object này thuần tham chiếu, không I/O, nên dựng mới là miễn phí.
+    """
+    return workflow_runtime.WorkflowCanary(
+        _CONTEXT_RUNTIME, cfgmod.read_settings,
+        graph_loader=lambda slug: load_workflow_graph(brain, slug),
+    )
 
 
 def workflow_manifests(brain: str) -> list[dict]:
@@ -4531,16 +4530,22 @@ async def execute_workflow(brain, slug, input="", tools=None, session_id=""):
         return
     # Phase 10 canary: mặc định allocation 0 nên vòng lặp cũ vẫn là đường duy nhất.
     # Lỗi ở đường mới không được cướp lượt chạy - rơi về runner cũ.
+    emitted = False
     try:
-        emitted = False
         async for event in execute_workflow_graph(brain, slug, input, tools, session_id):
             emitted = True
             yield event
         if emitted:
             return
     except Exception as _wf_exc:
-        print(f"[workflow graph] {type(_wf_exc).__name__} - dùng runner cũ",
-              file=__import__('sys').stderr)
+        print(f"[workflow graph] {type(_wf_exc).__name__}", file=__import__('sys').stderr)
+        if emitted:
+            # Đã phát event ra client rồi thì chạy lại bằng runner cũ là CHẠY HAI LẦN.
+            # Báo lỗi và dừng, để người dùng quyết định chạy lại.
+            yield {"type": "error",
+                   "content": "Workflow dừng giữa chừng ở đường mới. Không tự chạy lại "
+                              "để tránh làm hai lần; anh chạy lại nếu cần."}
+            return
     meta, _ = _read_md(wf_file)
     steps = meta.get("steps", []) or []
     vault_root = str(_brain_root(brain))

--- a/server/main.py
+++ b/server/main.py
@@ -71,6 +71,8 @@ import capability_executor   # Phase 6: one-use read lease + schema validation
 import readonly_path_runtime # Phase 6: exact-schema, two-round read-only canary
 import readonly_orchestrator # Phase 7: checkpointed multi-round read-only DAG
 import adaptive_context_runtime # Phase 8: state + sourced memory + lazy skill canaries
+import workflow_graph          # Phase 10: workflow -> capability graph (thuần dữ liệu)
+import workflow_runtime        # Phase 10: chạy graph có checkpoint/resume
 import write_path_runtime    # Phase 9: write có xác nhận, idempotency và reconcile
 from telegram_bot import TelegramBot, parse_chat_ids as tg_parse_ids
 import channel_context   # metadata kênh + gom file trả về kênh chat (port gateway hermes-agent)
@@ -4154,6 +4156,49 @@ def workflows_index(brain: str) -> list:
                     "steps": meta.get("steps", []) or []})
     return out
 
+_WORKFLOW_CANARY = None
+
+
+def _get_workflow_canary(brain):
+    """Khởi tạo lười; mặc định allocation 0 nên production không trả chi phí gì."""
+    global _WORKFLOW_CANARY
+    if _WORKFLOW_CANARY is None:
+        _WORKFLOW_CANARY = workflow_runtime.WorkflowCanary(
+            _CONTEXT_RUNTIME, cfgmod.read_settings,
+            graph_loader=lambda slug: load_workflow_graph(brain, slug),
+        )
+    return _WORKFLOW_CANARY
+
+
+def workflow_manifests(brain: str) -> list[dict]:
+    """WorkflowSource của Phase 10: manifest + hợp đồng, KHÔNG kèm thân prompt của node.
+
+    Workflow hỏng định nghĩa thì bỏ qua đúng workflow đó, không làm hỏng cả nguồn.
+    """
+    out = []
+    root = _workflows_dir(brain)
+    for f in sorted(root.glob("*.md")):
+        try:
+            meta, _ = _read_md(f)
+            graph = workflow_graph.compile_workflow(meta, f.stem)
+        except (workflow_graph.WorkflowContractError, Exception):
+            continue
+        out.append(workflow_graph.manifest_of(graph, relative_path=f.name))
+    return out
+
+
+def load_workflow_graph(brain: str, slug: str):
+    """Đọc một workflow thành đồ thị đã kiểm tra hợp lệ; None nếu thiếu hoặc sai."""
+    path = _workflows_dir(brain) / f"{slug}.md"
+    if not path.exists():
+        return None
+    try:
+        meta, _ = _read_md(path)
+        return workflow_graph.compile_workflow(meta, slug)
+    except Exception:
+        return None
+
+
 @app.get("/workflows")
 async def list_workflows(brain: str = Query("brain")):
     return {"workflows": workflows_index(brain)}
@@ -4311,58 +4356,102 @@ async def usage_refresh():
         return JSONResponse({"error": str(e)}, status_code=500)
 
 
-async def execute_workflow(brain, slug, input="", tools=None):
-    """Chạy workflow nhiều agent tuần tự, YIELD event dict (KHÔNG bọc SSE). Dùng CHUNG cho:
-      - /workflows/run  : user bấm ở Studio (full quyền, stream SSE).
-      - dispatcher Kanban: chạy nền không người xem → truyền tools=SAFE_FILE_TOOLS để agent
-        CHỈ thao tác file (không đụng MCP tiền/đơn) + cô lập MCP (strict rỗng). Task cần hành
-        động ra ngoài → dừng ở review cho người duyệt, KHÔNG tự làm.
-    tools=None → full (như cũ). list → giới hạn tool + cô lập MCP (an toàn nền)."""
-    wf_file = _workflows_dir(brain) / f"{slug}.md"
-    if not wf_file.exists():
-        yield {"type": "error", "content": "workflow not found"}
-        return
-    meta, _ = _read_md(wf_file)
-    steps = meta.get("steps", []) or []
+async def _run_workflow_step(node, prompt, mk, agent_sysprompt, sink):
+    """Chạy ĐÚNG một bước theo đúng ngữ nghĩa runner cũ: agent, kiểm chứng, retry.
+
+    Dùng chung cho cả hai đường. `sink` nhận event để đường graph đẩy ra SSE y như cũ.
+    """
+    agent_name, sysprompt, agent_model = agent_sysprompt(node.agent)
+    cur_prompt = prompt
+    out = ""
+    verified = None
+    attempt = 0
+    while True:
+        gcli = mk(sysprompt, agent_model)
+        out = ""
+        async for ev in gcli.query(cur_prompt):
+            if ev["type"] == "text":
+                await sink({"type": "step_text", "node": node.id, "content": ev["content"]})
+            elif ev["type"] == "tool_call":
+                await sink({"type": "step_tool", "node": node.id, "tool": ev["name"]})
+            elif ev["type"] == "final":
+                out = ev.get("content") or out
+            elif ev["type"] == "error":
+                await sink({"type": "step_error", "node": node.id, "content": ev["content"]})
+        if not node.verify_agent:
+            break
+        v_name, v_body, v_model = agent_sysprompt(node.verify_agent)
+        await sink({"type": "step_verify", "node": node.id, "agent": v_name, "attempt": attempt})
+        v_sys = (
+            v_body + "\n\nVAI TRÒ KIỂM CHỨNG: Bạn là người ĐÁNH GIÁ độc lập. "
+            "Mặc định GIẢ ĐỊNH kết quả dưới đây ĐANG SAI và phải tự chứng minh. "
+            "Kiểm tra thực tế (đọc file/chạy thử nếu cần), KHÔNG chỉ đọc lướt. "
+            'CHỈ trả JSON 1 dòng: {"pass":true|false,"reason":"ngắn gọn vì sao","fixes":"cần sửa gì nếu fail"}.'
+        )
+        v_prompt = (
+            f"NHIỆM VỤ GỐC:\n{prompt}\n\n"
+            f"KẾT QUẢ CẦN KIỂM CHỨNG:\n{out}\n\n"
+            "Đánh giá kết quả có ĐẠT nhiệm vụ không. Trả JSON như hướng dẫn."
+        )
+        vcli = mk(v_sys, v_model)
+        v_out = ""
+        async for ev in vcli.query(v_prompt):
+            if ev["type"] == "final":
+                v_out = ev.get("content") or v_out
+            elif ev["type"] == "error":
+                v_out = '{"pass":true,"reason":"verify lỗi, tạm chấp nhận"}'
+        vm = re.search(r"\{.*\}", v_out, re.DOTALL)
+        verdict = {}
+        if vm:
+            try:
+                verdict = json.loads(vm.group(0))
+            except json.JSONDecodeError:
+                verdict = {}
+        passed = bool(verdict.get("pass", True))
+        reason = verdict.get("reason", "")
+        fixes = verdict.get("fixes", "")
+        await sink({"type": "step_verify_result", "node": node.id, "passed": passed,
+                    "reason": reason, "attempt": attempt})
+        verified = passed
+        if passed or attempt >= node.max_retries:
+            break
+        attempt += 1
+        await sink({"type": "step_retry", "node": node.id, "attempt": attempt})
+        cur_prompt = (
+            f"{prompt}\n\n# KẾT QUẢ LẦN TRƯỚC (bị kiểm chứng đánh giá CHƯA ĐẠT):\n{out[:8000]}\n\n"
+            f"# PHẢN HỒI KIỂM CHỨNG:\n- Vấn đề: {reason}\n- Cần sửa: {fixes}\n"
+            "CẢI THIỆN kết quả lần trước theo phản hồi: giữ phần đã tốt, sửa đúng chỗ bị chê. Làm cho ĐẠT."
+        )
+    return {"output": out, "verified": verified, "attempts": attempt + 1,
+            "agent_name": agent_name}
+
+
+def _workflow_agent_helpers(brain, tools):
+    """Trả (_mk, _agent_sysprompt) dùng CHUNG cho runner cũ và đường graph Phase 10.
+
+    Tương đương giữa hai đường phải đến từ việc dùng chung code, không phải từ việc
+    chép cho giống. Mọi thay đổi ở đây tự động áp cho cả hai.
+    """
     vault_root = str(_brain_root(brain))
-    try:
-        # Agent workflow chạy cwd=brain, agent nền có MCP rỗng → chỉ nạp skill NATIVE từ
-        # .claude/skills. Đảm bảo đã migrate + mirror trước khi spawn (idempotent, rẻ).
-        system_sync.ensure_synced(vault_root)
-        system_sync.mirror_skills(vault_root)
-    except Exception:
-        pass
 
     def _mk(sysprompt, model=None):
-        # Agent model = Codex/ChatGPT → chạy qua Codex CLI (có tool file + MCP native của codex).
-        # CHỈ ở chế độ foreground (tools is None): codex không giới hạn tool được như Claude
-        # (--allowedTools), nên chạy nền an-toàn-file-only (tools != None) vẫn ép dùng Claude.
         if model and _is_codex_model(model) and tools is None and find_codex_cli():
-            openai_oauth.write_codex_auth()   # bắc cầu token ChatGPT → ~/.codex/auth.json
-            cc = CodexCLI(cwd=vault_root, tag="workflow", model=_codex_safe_model(model), instructions=sysprompt)
-            _apply_codex_hub(cc, vault_root)   # MCP + đúng brain cho cron/nhắc hẹn
+            openai_oauth.write_codex_auth()
+            cc = CodexCLI(cwd=vault_root, tag="workflow", model=_codex_safe_model(model),
+                          instructions=sysprompt)
+            _apply_codex_hub(cc, vault_root)
             return cc
-        c = claude_engine(system_prompt=sysprompt, cwd=vault_root, tag="workflow", allowed_tools=tools)
-        # Model Claude của AGENT (sonnet/opus/haiku/fable) được ÁP THẬT vào CLI.
-        # Rỗng → dùng model phụ (việc nền) nếu có, cuối cùng None = mặc định CLI.
+        c = claude_engine(system_prompt=sysprompt, cwd=vault_root, tag="workflow",
+                          allowed_tools=tools)
         c.model = ((model if not _is_codex_model(model) else "") or _aux_model() or None)
-        if tools is not None:   # chạy nền hạn chế → cô lập MCP + chặn Bash/Web
+        if tools is not None:
             _mcpf = _empty_mcp_file()
             if _mcpf:
-                c.mcp_config = _mcpf; c.mcp_strict = True
+                c.mcp_config = _mcpf
+                c.mcp_strict = True
             c.disallowed_tools = ["Bash", "WebFetch", "WebSearch", "Task"]
             c.max_wall_s = 300
         else:
-            # Ungated (allowed_tools=None, "chạy full quyền" - Studio bấm nút): plugin in-process
-            # CÓ nạp (claude_sdk_engine._mcp_servers gọi _plugins_server() khi allowed_tools rỗng)
-            # nên PHẢI gắn brain để ctx plugin (vd javis_generate_image) suy đúng vault - thiếu
-            # dòng này thì rơi về Brain Default y hệt bug 0.9.70 đã vá ở đường chat (Nợ 1,
-            # final-fix-gd2). KHÔNG gọi _apply_mcp() ở đây: nhánh này cố ý dựa vào setting_sources
-            # (claude_sdk_engine.py _options(): permission_mode=bypassPermissions +
-            # setting_sources=[user,project,local]) để kế thừa MCP/skill/auth có sẵn của máy như
-            # 1 phiên `claude` tương tác thật - đúng ý đầu file main.py "claude CLI đã cài trên
-            # máy → tự kế thừa MCP". Gọi apply_mcp sẽ ép gắn thêm cấu hình MCP hub, đổi hành vi
-            # ngoài phạm vi lỗi vault_root đang vá.
             c.javis_vault = vault_root
         return c
 
@@ -4376,6 +4465,94 @@ async def execute_workflow(brain, slug, input="", tools=None):
             + "\nLàm việc trong vault. Tập trung hoàn thành nhiệm vụ, trả kết quả rõ ràng, ngắn gọn."
         )
         return ameta.get("name", aslug), sysprompt, (ameta.get("model") or "").strip() or None
+
+    return _mk, _agent_sysprompt
+
+
+async def execute_workflow_graph(brain, slug, input="", tools=None, session_id=""):
+    """Đường Phase 10: cùng engine, cùng prompt, khác ở chỗ CÓ trạng thái.
+
+    Yield đúng bộ event mà dashboard đang nghe, cộng thêm `node` để trace theo đồ thị.
+    Không admitted thì trả None để caller dùng runner cũ.
+    """
+    graph = load_workflow_graph(brain, slug)
+    if graph is None:
+        return
+    trace = _CONTEXT_RUNTIME.start_turn(session_id or f"wf:{slug}", _brain_root(brain), "workflow")
+    canary = _get_workflow_canary(brain)
+    admission = canary.prepare(trace, graph, session_id or f"wf:{slug}")
+    if admission.action != "execute":
+        _CONTEXT_RUNTIME.finish(trace, "COMPLETED", admission.reason)
+        return
+    mk, agent_sysprompt = _workflow_agent_helpers(brain, tools)
+    queue: asyncio.Queue = asyncio.Queue()
+
+    async def sink(event):
+        await queue.put(event)
+
+    async def node_executor(node, prompt):
+        if node.kind != "model_step":
+            # Phase 10 chỉ tự chạy model step. Node capability/workflow con do tầng
+            # runtime quyết định; node ghi đã dừng hỏi trước khi tới đây.
+            return {"output": "", "error": f"node_kind_not_executable:{node.kind}"}
+        return await _run_workflow_step(node, prompt, mk, agent_sysprompt, sink)
+
+    async def drive():
+        try:
+            return await canary.run(trace, graph, input or "", session_id or f"wf:{slug}",
+                                    node_executor, sink)
+        finally:
+            await queue.put(None)
+
+    task = asyncio.create_task(drive())
+    while True:
+        event = await queue.get()
+        if event is None:
+            break
+        yield event
+    result = await task
+    _CONTEXT_RUNTIME.finish(
+        trace, "COMPLETED" if result.status == "COMPLETED" else "FAILED", result.stop_reason)
+    if result.status == "WAITING_USER":
+        yield {"type": "wait_user", "node": result.pending_node_id,
+               "task_id": result.task_id, "reason": result.stop_reason}
+
+
+async def execute_workflow(brain, slug, input="", tools=None, session_id=""):
+    """Chạy workflow nhiều agent tuần tự, YIELD event dict (KHÔNG bọc SSE). Dùng CHUNG cho:
+      - /workflows/run  : user bấm ở Studio (full quyền, stream SSE).
+      - dispatcher Kanban: chạy nền không người xem → truyền tools=SAFE_FILE_TOOLS để agent
+        CHỈ thao tác file (không đụng MCP tiền/đơn) + cô lập MCP (strict rỗng). Task cần hành
+        động ra ngoài → dừng ở review cho người duyệt, KHÔNG tự làm.
+    tools=None → full (như cũ). list → giới hạn tool + cô lập MCP (an toàn nền)."""
+    wf_file = _workflows_dir(brain) / f"{slug}.md"
+    if not wf_file.exists():
+        yield {"type": "error", "content": "workflow not found"}
+        return
+    # Phase 10 canary: mặc định allocation 0 nên vòng lặp cũ vẫn là đường duy nhất.
+    # Lỗi ở đường mới không được cướp lượt chạy - rơi về runner cũ.
+    try:
+        emitted = False
+        async for event in execute_workflow_graph(brain, slug, input, tools, session_id):
+            emitted = True
+            yield event
+        if emitted:
+            return
+    except Exception as _wf_exc:
+        print(f"[workflow graph] {type(_wf_exc).__name__} - dùng runner cũ",
+              file=__import__('sys').stderr)
+    meta, _ = _read_md(wf_file)
+    steps = meta.get("steps", []) or []
+    vault_root = str(_brain_root(brain))
+    try:
+        # Agent workflow chạy cwd=brain, agent nền có MCP rỗng → chỉ nạp skill NATIVE từ
+        # .claude/skills. Đảm bảo đã migrate + mirror trước khi spawn (idempotent, rẻ).
+        system_sync.ensure_synced(vault_root)
+        system_sync.mirror_skills(vault_root)
+    except Exception:
+        pass
+
+    _mk, _agent_sysprompt = _workflow_agent_helpers(brain, tools)
 
     yield {"type": "start", "workflow": meta.get("name", slug), "steps": len(steps)}
     prev = ""

--- a/server/workflow_graph.py
+++ b/server/workflow_graph.py
@@ -1,0 +1,387 @@
+"""Adaptive Runtime Phase 10: workflow như capability graph.
+
+Tầng này THUẦN DỮ LIỆU: không I/O, không gọi model, không đụng SQLite. Nó chỉ biến
+định nghĩa workflow thành một đồ thị đã kiểm tra hợp lệ, kèm hợp đồng input/output
+và revision content-addressed. Nhờ vậy validation chạy được trong test mà không cần
+dựng nguyên hệ.
+
+Hai nguồn đồ thị:
+
+- `compile_legacy_workflow`: adapter cho định dạng ĐANG DÙNG (`steps[]` với đúng bốn
+  trường agent/task/verify_agent/max_retries). Workflow cũ không có hợp đồng dữ liệu
+  nào cả, nên adapter phải TỰ SUY RA chứ không đọc được từ file. Suy ra theo hướng
+  giữ nguyên hành vi: một chuỗi vào, chuỗi của bước cuối đi ra.
+- `compile_native_workflow`: định dạng mới có `nodes[]`, cho phép depends_on, điều
+  kiện, nhánh song song, chờ người dùng và gọi workflow con theo revision.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+WORKFLOW_GRAPH_VERSION = "workflow-graph-v1"
+LEGACY_ADAPTER_VERSION = "legacy-linear-v1"
+NATIVE_ADAPTER_VERSION = "native-dag-v1"
+
+# Trần an toàn của policy, không phải thuật toán chọn. Vượt trần là từ chối biên dịch
+# chứ không cắt bớt im lặng.
+MAX_NODES = 64
+MAX_NESTING_DEPTH = 3
+MAX_PARALLEL_WIDTH = 8
+
+NODE_KINDS = frozenset({
+    "model_step", "capability", "condition", "wait_user", "workflow_call", "compensation",
+})
+# Phase 10 không mở effect `dangerous` trong bất kỳ cấu hình nào, y như Phase 9.
+ALLOWED_EFFECTS = frozenset({"none", "read", "write"})
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,79}$")
+_NODE_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
+class WorkflowContractError(ValueError):
+    """Định nghĩa workflow không hợp lệ. Luôn fail-closed, không tự chữa."""
+
+
+def _sha(value: Any) -> str:
+    return hashlib.sha256(json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str
+    ).encode("utf-8", errors="replace")).hexdigest()
+
+
+def _int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return int(default)
+
+
+@dataclass(frozen=True)
+class WorkflowNode:
+    id: str
+    kind: str
+    depends_on: tuple[str, ...] = ()
+    # model_step
+    agent: str = ""
+    task: str = ""
+    verify_agent: str = ""
+    max_retries: int = 1
+    # capability
+    capability_id: str = ""
+    capability_name: str = ""
+    effect: str = "none"
+    arguments: dict = field(default_factory=dict)
+    # workflow_call
+    workflow_slug: str = ""
+    workflow_revision: str = ""
+    # condition
+    when: dict = field(default_factory=dict)
+    # compensation
+    compensates: str = ""
+    # wait_user
+    prompt: str = ""
+    metadata: dict = field(default_factory=dict)
+
+    @property
+    def is_write(self) -> bool:
+        return self.kind == "capability" and self.effect == "write"
+
+
+@dataclass(frozen=True)
+class WorkflowGraph:
+    slug: str
+    name: str
+    description: str
+    status: str
+    nodes: tuple[WorkflowNode, ...]
+    input_contract: dict
+    output_contract: dict
+    output_node_id: str
+    revision: str
+    source_hash: str
+    adapter: str
+    resumable: bool
+    max_risk: str
+    compensation: dict
+    graph_version: str = WORKFLOW_GRAPH_VERSION
+
+    def node(self, node_id: str) -> WorkflowNode | None:
+        for item in self.nodes:
+            if item.id == node_id:
+                return item
+        return None
+
+    @property
+    def write_node_ids(self) -> tuple[str, ...]:
+        return tuple(x.id for x in self.nodes if x.is_write)
+
+    @property
+    def nested_slugs(self) -> tuple[str, ...]:
+        return tuple(dict.fromkeys(
+            x.workflow_slug for x in self.nodes if x.kind == "workflow_call" and x.workflow_slug
+        ))
+
+    def execution_layers(self) -> tuple[tuple[str, ...], ...]:
+        """Chia node thành các lớp chạy được song song, tôn trọng depends_on."""
+        remaining = {x.id: set(x.depends_on) for x in self.nodes}
+        done: set[str] = set()
+        layers: list[tuple[str, ...]] = []
+        while remaining:
+            ready = tuple(sorted(k for k, deps in remaining.items() if deps <= done))
+            if not ready:  # pragma: no cover - validate_graph đã chặn chu trình
+                raise WorkflowContractError("workflow_graph_cycle")
+            layers.append(ready)
+            for key in ready:
+                remaining.pop(key, None)
+            done.update(ready)
+        return tuple(layers)
+
+
+def _validate_nodes(nodes: list[WorkflowNode]) -> None:
+    if not nodes:
+        raise WorkflowContractError("workflow_has_no_nodes")
+    if len(nodes) > MAX_NODES:
+        raise WorkflowContractError("workflow_too_many_nodes")
+    seen: set[str] = set()
+    for node in nodes:
+        if not _NODE_ID_RE.match(node.id):
+            raise WorkflowContractError(f"invalid_node_id:{node.id[:40]}")
+        if node.id in seen:
+            raise WorkflowContractError(f"duplicate_node_id:{node.id[:40]}")
+        if node.kind not in NODE_KINDS:
+            raise WorkflowContractError(f"unknown_node_kind:{node.kind[:40]}")
+        # depends_on chỉ được trỏ về node ĐÃ khai trước đó. Luật này khiến chu trình
+        # là bất khả thi ngay từ cấu trúc, mà vẫn diễn tả được mọi DAG (mọi DAG đều
+        # có ít nhất một thứ tự topo).
+        for dep in node.depends_on:
+            if dep not in seen:
+                raise WorkflowContractError(f"unknown_or_forward_dependency:{dep[:40]}")
+        if node.kind == "model_step" and not node.agent:
+            raise WorkflowContractError(f"model_step_without_agent:{node.id}")
+        if node.kind == "capability":
+            if node.effect not in ALLOWED_EFFECTS:
+                raise WorkflowContractError(f"effect_not_allowed:{node.effect[:40]}")
+            if not node.capability_id and not node.capability_name:
+                raise WorkflowContractError(f"capability_node_without_target:{node.id}")
+        if node.kind == "workflow_call":
+            if not _SLUG_RE.match(node.workflow_slug or ""):
+                raise WorkflowContractError(f"invalid_nested_slug:{node.id}")
+            # Ghim revision là BẮT BUỘC: workflow con đổi giữa chừng mà cha không biết
+            # thì lineage vô nghĩa và resume không tái lập được.
+            if not node.workflow_revision:
+                raise WorkflowContractError(f"nested_workflow_without_revision:{node.id}")
+        if node.kind == "compensation":
+            if node.compensates not in seen:
+                raise WorkflowContractError(f"compensation_for_unknown_node:{node.id}")
+        seen.add(node.id)
+    widest = max(len(layer) for layer in _layers_of(nodes))
+    if widest > MAX_PARALLEL_WIDTH:
+        raise WorkflowContractError("workflow_parallel_width_exceeded")
+
+
+def _layers_of(nodes: list[WorkflowNode]) -> list[tuple[str, ...]]:
+    remaining = {x.id: set(x.depends_on) for x in nodes}
+    done: set[str] = set()
+    layers: list[tuple[str, ...]] = []
+    while remaining:
+        ready = tuple(sorted(k for k, deps in remaining.items() if deps <= done))
+        if not ready:
+            raise WorkflowContractError("workflow_graph_cycle")
+        layers.append(ready)
+        for key in ready:
+            remaining.pop(key, None)
+        done.update(ready)
+    return layers
+
+
+def _risk_of(nodes: list[WorkflowNode]) -> str:
+    if any(x.is_write for x in nodes):
+        return "write"
+    if any(x.kind == "capability" and x.effect == "read" for x in nodes):
+        return "read"
+    return "none"
+
+
+def compile_legacy_workflow(meta: dict, slug: str) -> WorkflowGraph:
+    """Bọc định dạng workflow đang dùng vào đồ thị, GIỮ NGUYÊN hành vi.
+
+    Workflow cũ chạy tuần tự, truyền dữ liệu bằng thay chuỗi `{{prev}}`, và chỉ output
+    của bước cuối là quan sát được. Adapter giữ đúng cả ba điểm đó: node xếp thành một
+    chuỗi thẳng, cạnh dữ liệu vẫn là chuỗi, `output_node_id` là node cuối.
+    """
+    meta = meta if isinstance(meta, dict) else {}
+    steps = meta.get("steps")
+    steps = steps if isinstance(steps, list) else []
+    nodes: list[WorkflowNode] = []
+    for index, step in enumerate(steps):
+        if not isinstance(step, dict):
+            raise WorkflowContractError(f"legacy_step_not_mapping:{index}")
+        agent = str(step.get("agent") or "").strip()
+        if not agent:
+            raise WorkflowContractError(f"legacy_step_without_agent:{index}")
+        nodes.append(WorkflowNode(
+            id=f"s{index}",
+            kind="model_step",
+            depends_on=(f"s{index - 1}",) if index else (),
+            agent=agent,
+            task=str(step.get("task") or ""),
+            verify_agent=str(step.get("verify_agent") or "").strip(),
+            # Giữ nguyên phép quy đổi của runner cũ: thiếu/0/không parse được -> 0.
+            max_retries=max(0, _int(step.get("max_retries", 1), 0)),
+            metadata={"legacy_index": index},
+        ))
+    _validate_nodes(nodes)
+    payload = {
+        "slug": slug,
+        "adapter": LEGACY_ADAPTER_VERSION,
+        "graph_version": WORKFLOW_GRAPH_VERSION,
+        "steps": [{
+            "id": x.id, "agent": x.agent, "task": x.task,
+            "verify_agent": x.verify_agent, "max_retries": x.max_retries,
+        } for x in nodes],
+    }
+    return WorkflowGraph(
+        slug=slug,
+        name=str(meta.get("name") or slug),
+        description=str(meta.get("description") or ""),
+        status=str(meta.get("status") or "active"),
+        nodes=tuple(nodes),
+        # Hợp đồng SUY RA, không đọc được từ file: workflow cũ không khai gì cả.
+        input_contract={
+            "type": "object",
+            "properties": {"input": {"type": "string"}},
+            "required": [],
+            "additionalProperties": False,
+            "derived": True,
+        },
+        output_contract={
+            "type": "object",
+            "properties": {"output": {"type": "string"}},
+            "required": ["output"],
+            "additionalProperties": False,
+            "derived": True,
+            "note": "Chỉ output của node cuối, đúng như runner cũ.",
+        },
+        output_node_id=nodes[-1].id,
+        revision=_sha(payload),
+        source_hash=_sha(meta),
+        adapter=LEGACY_ADAPTER_VERSION,
+        # Workflow cũ toàn model step nên chạy lại một node là an toàn.
+        resumable=True,
+        max_risk=_risk_of(nodes),
+        compensation={},
+    )
+
+
+def compile_native_workflow(meta: dict, slug: str) -> WorkflowGraph:
+    """Định dạng mới: `nodes[]` khai tường minh depends_on, effect và workflow con."""
+    meta = meta if isinstance(meta, dict) else {}
+    raw_nodes = meta.get("nodes")
+    raw_nodes = raw_nodes if isinstance(raw_nodes, list) else []
+    nodes: list[WorkflowNode] = []
+    for index, item in enumerate(raw_nodes):
+        if not isinstance(item, dict):
+            raise WorkflowContractError(f"node_not_mapping:{index}")
+        depends = item.get("depends_on") or []
+        depends = depends if isinstance(depends, list) else [depends]
+        nodes.append(WorkflowNode(
+            id=str(item.get("id") or f"n{index}"),
+            kind=str(item.get("kind") or "model_step"),
+            depends_on=tuple(str(x) for x in depends if str(x)),
+            agent=str(item.get("agent") or "").strip(),
+            task=str(item.get("task") or ""),
+            verify_agent=str(item.get("verify_agent") or "").strip(),
+            max_retries=max(0, _int(item.get("max_retries", 1), 0)),
+            capability_id=str(item.get("capability_id") or "").strip(),
+            capability_name=str(item.get("capability") or item.get("capability_name") or "").strip(),
+            effect=str(item.get("effect") or "none").strip(),
+            arguments=item.get("arguments") if isinstance(item.get("arguments"), dict) else {},
+            workflow_slug=str(item.get("workflow") or item.get("workflow_slug") or "").strip(),
+            workflow_revision=str(item.get("workflow_revision") or "").strip(),
+            when=item.get("when") if isinstance(item.get("when"), dict) else {},
+            compensates=str(item.get("compensates") or "").strip(),
+            prompt=str(item.get("prompt") or ""),
+            metadata={"declared_index": index},
+        ))
+    _validate_nodes(nodes)
+    output_node = str(meta.get("output_node") or (nodes[-1].id if nodes else ""))
+    if not any(x.id == output_node for x in nodes):
+        raise WorkflowContractError(f"unknown_output_node:{output_node[:40]}")
+    declared_input = meta.get("input_contract")
+    declared_output = meta.get("output_contract")
+    payload = {
+        "slug": slug, "adapter": NATIVE_ADAPTER_VERSION,
+        "graph_version": WORKFLOW_GRAPH_VERSION,
+        "output_node": output_node,
+        "nodes": [{
+            "id": x.id, "kind": x.kind, "depends_on": list(x.depends_on),
+            "agent": x.agent, "task": x.task, "verify_agent": x.verify_agent,
+            "max_retries": x.max_retries, "capability_id": x.capability_id,
+            "capability_name": x.capability_name, "effect": x.effect,
+            "arguments": x.arguments, "workflow_slug": x.workflow_slug,
+            "workflow_revision": x.workflow_revision, "when": x.when,
+            "compensates": x.compensates, "prompt": x.prompt,
+        } for x in nodes],
+        "input_contract": declared_input, "output_contract": declared_output,
+    }
+    compensation = {x.compensates: x.id for x in nodes if x.kind == "compensation"}
+    return WorkflowGraph(
+        slug=slug,
+        name=str(meta.get("name") or slug),
+        description=str(meta.get("description") or ""),
+        status=str(meta.get("status") or "active"),
+        nodes=tuple(nodes),
+        input_contract=declared_input if isinstance(declared_input, dict) else {
+            "type": "object", "properties": {"input": {"type": "string"}},
+            "required": [], "additionalProperties": False, "derived": True,
+        },
+        output_contract=declared_output if isinstance(declared_output, dict) else {
+            "type": "object", "properties": {"output": {"type": "string"}},
+            "required": ["output"], "additionalProperties": False, "derived": True,
+        },
+        output_node_id=output_node,
+        revision=_sha(payload),
+        source_hash=_sha(meta),
+        adapter=NATIVE_ADAPTER_VERSION,
+        # Có node write mà không khai được đường bù thì KHÔNG tự nhận là resume được:
+        # resume một workflow từng ghi ra ngoài là quyết định phải có bằng chứng.
+        resumable=all(x.id in compensation for x in nodes if x.is_write) or not any(
+            x.is_write for x in nodes),
+        max_risk=_risk_of(nodes),
+        compensation=compensation,
+    )
+
+
+def compile_workflow(meta: dict, slug: str) -> WorkflowGraph:
+    """Chọn adapter theo định dạng file, không cần người dùng khai."""
+    if not _SLUG_RE.match(str(slug or "")):
+        raise WorkflowContractError(f"invalid_workflow_slug:{str(slug)[:40]}")
+    if isinstance((meta or {}).get("nodes"), list):
+        return compile_native_workflow(meta, slug)
+    return compile_legacy_workflow(meta, slug)
+
+
+def manifest_of(graph: WorkflowGraph, relative_path: str = "") -> dict:
+    """Manifest cho Registry: metadata + hợp đồng, KHÔNG kèm thân prompt của node."""
+    return {
+        "slug": graph.slug,
+        "name": graph.name,
+        "description": graph.description,
+        "status": graph.status,
+        "revision": graph.revision,
+        "source_hash": graph.source_hash,
+        "adapter": graph.adapter,
+        "graph_version": graph.graph_version,
+        "node_count": len(graph.nodes),
+        "node_kinds": sorted({x.kind for x in graph.nodes}),
+        "max_risk": graph.max_risk,
+        "resumable": graph.resumable,
+        "has_write_node": bool(graph.write_node_ids),
+        "nested_slugs": list(graph.nested_slugs),
+        "input_contract": graph.input_contract,
+        "output_contract": graph.output_contract,
+        "relative_path": str(relative_path or "")[:500],
+    }

--- a/server/workflow_runtime.py
+++ b/server/workflow_runtime.py
@@ -357,7 +357,14 @@ class WorkflowCanary:
                                  "verified": result.get("verified")})
                 # Checkpoint sau MỖI lô, trước khi chạy lô kế: tiến trình chết ở đây
                 # thì resume không mất phần đã xong.
-                self._checkpoint(trace, state)
+                if not self._checkpoint(trace, state):
+                    # Checkpoint hỏng thường là do OCC: một tiến trình khác đã resume
+                    # đúng task này. Đi tiếp là hai bên cùng chạy một node - dừng ngay.
+                    await _emit({"type": "error", "content": "checkpoint_failed"})
+                    return WorkflowRunResult(
+                        "FAILED", state.get("output") or "", "checkpoint_failed",
+                        getattr(trace, "task_id", ""), tuple(completed), tuple(reused),
+                        "", events)
 
         output_entry = state["nodes"].get(graph.output_node_id) or {}
         failed = [nid for nid, item in state["nodes"].items() if item.get("status") == "FAILED"]

--- a/server/workflow_runtime.py
+++ b/server/workflow_runtime.py
@@ -387,6 +387,14 @@ class WorkflowCanary:
                                          state.get("stop_reason") or "wait_user_node",
                                          task_id, pending_node_id=pending)
             node = graph.node(pending)
+            if node is not None and node.is_write:
+                # Phase 10 mới chỉ ĐƯA node ghi ra hỏi, chưa tự thực thi (việc đó thuộc
+                # đường write của Phase 9). Nói thẳng ra thay vì lặng lẽ dừng lại lần
+                # nữa - dừng vô hạn sau khi người dùng đã đồng ý là hành vi dối trá.
+                return WorkflowRunResult(
+                    "WAITING_USER", state.get("output") or "",
+                    "write_execution_not_enabled_in_this_phase", task_id,
+                    pending_node_id=pending)
             if node is not None and node.kind == "wait_user":
                 state["nodes"][pending] = {
                     "status": "COMPLETED", "output": state.get("input") or "",

--- a/server/workflow_runtime.py
+++ b/server/workflow_runtime.py
@@ -1,0 +1,399 @@
+"""Adaptive Runtime Phase 10: chạy workflow như capability graph, có checkpoint.
+
+Điểm mấu chốt của phase này KHÔNG phải là viết một engine workflow mới. Runner cũ đã
+chạy được prompt chain; cái nó thiếu là TRẠNG THÁI. Task Kanban chạy workflow mà tiến
+trình chết là chạy lại từ bước 0, kể cả những bước đã ghi ra ngoài. Phase 10 bọc đúng
+định dạng cũ vào cỗ máy đồ thị + checkpoint của runtime mới, giữ nguyên engine, giữ
+nguyên prompt, giữ nguyên bộ event mà dashboard đang nghe.
+
+Ba bất biến của phase này:
+
+1. **Node đã xong không chạy lại.** Resume đọc checkpoint, node `COMPLETED` giữ nguyên
+   output cũ. Với node ghi thì đây là ranh giới không được phép sai.
+2. **Node ghi không bao giờ tự chạy.** Workflow chạy nền không có ai để hỏi, nên gặp
+   node ghi là dừng ở `WAITING_USER` và trả quyền quyết định về người dùng. Đây là lý
+   do `wait_user` nằm trong danh sách node kind của spec.
+3. **Workflow con ghim theo revision.** Gọi workflow con mà không ghim revision thì
+   lineage vô nghĩa và resume không tái lập được, nên tầng đồ thị bắt buộc trường này.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Optional
+
+import context_runtime
+import secrets_store
+import workflow_graph
+from workflow_graph import WorkflowGraph, WorkflowNode
+
+WORKFLOW_POLICY_VERSION = "workflow-graph-canary-v1"
+STATE_SCHEMA_VERSION = "workflow-state-v1"
+
+# Executor của một node: nhận (node, prompt đã nội suy) -> (text, events).
+NodeExecutor = Callable[[WorkflowNode, str], Awaitable[dict]]
+GraphLoader = Callable[[str], Optional[WorkflowGraph]]
+
+
+def _int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return int(default)
+
+
+def _sha(value: Any) -> str:
+    return hashlib.sha256(json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str
+    ).encode("utf-8", errors="replace")).hexdigest()
+
+
+@dataclass(frozen=True)
+class WorkflowPolicy:
+    mode: str
+    allocation_basis_points: int
+    salt: str
+    allowed_slugs: tuple[str, ...]
+    max_nodes: int
+    max_parallel: int
+    node_timeout_seconds: float
+    max_nesting_depth: int
+    allow_write_nodes: bool
+    version: str
+
+    @classmethod
+    def from_settings(cls, settings: dict) -> "WorkflowPolicy":
+        runtime = (settings or {}).get("context_runtime") or {}
+        runtime = runtime if isinstance(runtime, dict) else {}
+        raw = runtime.get("workflow_canary")
+        raw = raw if isinstance(raw, dict) else {}
+        return cls(
+            mode=str(raw.get("mode", runtime.get("mode", "off"))).casefold(),
+            allocation_basis_points=max(0, min(_int(raw.get("allocation_basis_points"), 0), 10_000)),
+            salt=str(raw.get("salt") or WORKFLOW_POLICY_VERSION),
+            # Danh sách rỗng = fail-closed, y hệt các phase trước.
+            allowed_slugs=tuple(str(x).strip() for x in (raw.get("allowed_slugs") or []) if str(x).strip()),
+            max_nodes=max(1, min(_int(raw.get("max_nodes"), 24), workflow_graph.MAX_NODES)),
+            max_parallel=max(1, min(_int(raw.get("max_parallel"), 3), workflow_graph.MAX_PARALLEL_WIDTH)),
+            node_timeout_seconds=max(5.0, min(float(_int(raw.get("node_timeout_seconds"), 300)), 1800.0)),
+            max_nesting_depth=max(0, min(_int(raw.get("max_nesting_depth"), 1),
+                                         workflow_graph.MAX_NESTING_DEPTH)),
+            # Node ghi trong workflow LUÔN phải hỏi người dùng. Cờ này chỉ quyết định
+            # workflow có node ghi thì được chạy tới chỗ hỏi, hay bị chặn từ đầu.
+            allow_write_nodes=bool(raw.get("allow_write_nodes", False)),
+            version=str(raw.get("policy_version") or WORKFLOW_POLICY_VERSION)[:120],
+        )
+
+    def admits(self, slug: str, session_id: str) -> tuple[bool, int, str]:
+        from fast_path_runtime import stable_bucket
+        bucket = stable_bucket(session_id, self.salt)
+        if self.mode not in ("canary", "on"):
+            return False, bucket, "mode_not_canary"
+        if bucket >= self.allocation_basis_points:
+            return False, bucket, "outside_allocation"
+        if slug not in self.allowed_slugs:
+            return False, bucket, "workflow_not_allowlisted"
+        return True, bucket, "admitted"
+
+
+@dataclass(frozen=True)
+class WorkflowAdmission:
+    action: str
+    reason: str
+    graph: WorkflowGraph | None = None
+    bucket: Optional[int] = None
+    policy_version: str = WORKFLOW_POLICY_VERSION
+    message: str = ""
+
+
+@dataclass
+class WorkflowRunResult:
+    status: str
+    output: str = ""
+    stop_reason: str = ""
+    task_id: str = ""
+    completed_nodes: tuple[str, ...] = ()
+    reused_nodes: tuple[str, ...] = ()
+    pending_node_id: str = ""
+    events: list[dict] = field(default_factory=list)
+
+
+class WorkflowCanary:
+    """Chạy một `WorkflowGraph`, checkpoint sau từng node, resume không chạy lại."""
+
+    def __init__(self, runtime: context_runtime.ObserveRuntime,
+                 settings_reader: Callable[[], dict],
+                 graph_loader: GraphLoader | None = None,
+                 state_encryptor: Callable[[str], str] | None = None,
+                 state_decryptor: Callable[[str], str] | None = None):
+        self.runtime = runtime
+        self.settings_reader = settings_reader
+        self.graph_loader = graph_loader
+        self.state_encryptor = state_encryptor or secrets_store.encrypt_required
+        self.state_decryptor = state_decryptor or secrets_store.decrypt
+
+    def policy(self) -> WorkflowPolicy:
+        try:
+            return WorkflowPolicy.from_settings(self.settings_reader() or {})
+        except Exception:
+            return WorkflowPolicy.from_settings({})
+
+    # ------------------------------------------------------------------ admission
+
+    def prepare(self, trace, graph: WorkflowGraph, session_id: str) -> WorkflowAdmission:
+        policy = self.policy()
+        if not trace:
+            return WorkflowAdmission("legacy", "trace_unavailable", policy_version=policy.version)
+        admitted, bucket, reason = policy.admits(graph.slug, session_id)
+        if not admitted:
+            return WorkflowAdmission("legacy", reason, bucket=bucket, policy_version=policy.version)
+        if len(graph.nodes) > policy.max_nodes:
+            return WorkflowAdmission("legacy", "graph_too_large", bucket=bucket,
+                                     policy_version=policy.version)
+        if graph.write_node_ids and not policy.allow_write_nodes:
+            return WorkflowAdmission("legacy", "write_nodes_not_enabled", bucket=bucket,
+                                     policy_version=policy.version)
+        path = self.runtime.pin_execution_path(
+            trace, "workflow", bucket, policy.version, "workflow_admission")
+        if path != "workflow":
+            return WorkflowAdmission("legacy", "task_already_pinned", bucket=bucket,
+                                     policy_version=policy.version)
+        return WorkflowAdmission("execute", "admitted", graph, bucket, policy.version)
+
+    # ------------------------------------------------------------------ state
+
+    def _initial_state(self, graph: WorkflowGraph, input_text: str, session_id: str,
+                       depth: int = 0) -> dict:
+        return {
+            "schema_version": STATE_SCHEMA_VERSION,
+            "policy_version": self.policy().version,
+            "workflow_slug": graph.slug,
+            "workflow_revision": graph.revision,
+            "graph_version": graph.graph_version,
+            "adapter": graph.adapter,
+            "session_id": str(session_id or ""),
+            "input": str(input_text or ""),
+            "depth": int(depth),
+            "status": "RUNNING",
+            "nodes": {x.id: {"status": "PENDING", "output": "", "attempts": 0,
+                             "verified": None, "error": ""} for x in graph.nodes},
+            "pending_node_id": "",
+            "output": "",
+            "stop_reason": "",
+            "created_at": 0.0,
+        }
+
+    def _checkpoint(self, trace, state: dict, initialize: bool = False) -> bool:
+        payload = json.dumps(state, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        try:
+            encrypted = self.state_encryptor(payload)
+        except Exception:
+            return False
+        digest = _sha(state)
+        if initialize:
+            try:
+                objective = self.state_encryptor(
+                    f"workflow:{state['workflow_slug']}@{state['workflow_revision']}")
+            except Exception:
+                return False
+            return self.runtime.initialize_orchestrator(
+                trace, _sha(state["session_id"]), objective, encrypted, digest,
+                state["status"], {"kind": "workflow"}, None)
+        return self.runtime.checkpoint_orchestrator(trace, encrypted, digest, state["status"])
+
+    def load_state(self, task_id: str) -> dict | None:
+        snapshot = self.runtime.load_orchestrator_checkpoint(task_id)
+        if not snapshot or not snapshot.get("checkpoint"):
+            return None
+        try:
+            state = json.loads(self.state_decryptor(snapshot["checkpoint"]["state_encrypted"]))
+        except Exception:
+            return None
+        if state.get("schema_version") != STATE_SCHEMA_VERSION:
+            return None
+        return state
+
+    # ------------------------------------------------------------------ execution
+
+    @staticmethod
+    def _interpolate(node: WorkflowNode, state: dict, graph: WorkflowGraph) -> str:
+        """Giữ đúng ngữ nghĩa cũ: `{{input}}` và `{{prev}}` là thay chuỗi, không hơn."""
+        previous = ""
+        if node.depends_on:
+            # Runner cũ chỉ thấy output của bước LIỀN TRƯỚC. Với đồ thị, "liền trước"
+            # là dependency khai đầu tiên - trùng khớp với chuỗi thẳng của adapter cũ.
+            previous = str((state["nodes"].get(node.depends_on[0]) or {}).get("output") or "")
+        return node.task.replace("{{input}}", state.get("input") or "").replace(
+            "{{prev}}", previous)
+
+    async def _run_node(self, node: WorkflowNode, state: dict, graph: WorkflowGraph,
+                        executor: NodeExecutor, policy: WorkflowPolicy) -> dict:
+        prompt = self._interpolate(node, state, graph)
+        try:
+            result = await asyncio.wait_for(
+                executor(node, prompt), timeout=policy.node_timeout_seconds)
+        except asyncio.TimeoutError:
+            return {"status": "FAILED", "output": "", "error": "node_timeout"}
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return {"status": "FAILED", "output": "", "error": f"node_error:{type(exc).__name__}"}
+        result = result if isinstance(result, dict) else {}
+        return {
+            "status": "COMPLETED" if not result.get("error") else "FAILED",
+            "output": str(result.get("output") or ""),
+            "verified": result.get("verified"),
+            "attempts": _int(result.get("attempts"), 1),
+            "error": str(result.get("error") or ""),
+        }
+
+    async def run(self, trace, graph: WorkflowGraph, input_text: str, session_id: str,
+                  executor: NodeExecutor, emit: Callable[[dict], Awaitable[None]] | None = None,
+                  resume_state: dict | None = None, depth: int = 0) -> WorkflowRunResult:
+        policy = self.policy()
+        events: list[dict] = []
+
+        async def _emit(event: dict) -> None:
+            events.append(event)
+            if emit is not None:
+                await emit(event)
+
+        state = resume_state or self._initial_state(graph, input_text, session_id, depth)
+        reused: list[str] = []
+        if resume_state is not None:
+            # Ghim lại: revision đổi giữa chừng thì KHÔNG resume, vì node đã xong
+            # không còn tương ứng với đồ thị hiện tại.
+            if state.get("workflow_revision") != graph.revision:
+                return WorkflowRunResult("FAILED", stop_reason="workflow_revision_mismatch",
+                                         task_id=getattr(trace, "task_id", ""))
+            reused = [nid for nid, item in state["nodes"].items()
+                      if item.get("status") == "COMPLETED"]
+            await _emit({"type": "resume", "reused": len(reused),
+                         "workflow": graph.name})
+        else:
+            state["created_at"] = time.time()
+            if not self._checkpoint(trace, state, initialize=True):
+                return WorkflowRunResult("FAILED", stop_reason="checkpoint_unavailable",
+                                         task_id=getattr(trace, "task_id", ""))
+            await _emit({"type": "start", "workflow": graph.name, "steps": len(graph.nodes)})
+
+        completed: list[str] = []
+        for layer in graph.execution_layers():
+            runnable = []
+            for node_id in layer:
+                node = graph.node(node_id)
+                entry = state["nodes"].get(node_id) or {}
+                if entry.get("status") == "COMPLETED":
+                    continue  # BẤT BIẾN 1: node đã xong không bao giờ chạy lại.
+                if any((state["nodes"].get(dep) or {}).get("status") != "COMPLETED"
+                       for dep in node.depends_on):
+                    state["nodes"][node_id] = {**entry, "status": "SKIPPED",
+                                               "error": "dependency_failed"}
+                    continue
+                runnable.append(node)
+
+            # BẤT BIẾN 2: gặp node ghi là dừng và hỏi, không tự chạy.
+            for node in runnable:
+                if node.is_write or node.kind == "wait_user":
+                    state["pending_node_id"] = node.id
+                    state["status"] = "WAITING_USER"
+                    state["stop_reason"] = ("write_node_needs_confirmation"
+                                            if node.is_write else "wait_user_node")
+                    self._checkpoint(trace, state)
+                    await _emit({"type": "wait_user", "node": node.id,
+                                 "reason": state["stop_reason"],
+                                 "prompt": node.prompt or node.task})
+                    return WorkflowRunResult(
+                        "WAITING_USER", state.get("output") or "", state["stop_reason"],
+                        getattr(trace, "task_id", ""), tuple(completed), tuple(reused),
+                        node.id, events)
+
+            if not runnable:
+                continue
+
+            for node in runnable:
+                if node.kind == "workflow_call":
+                    if depth >= policy.max_nesting_depth:
+                        state["nodes"][node.id] = {"status": "FAILED", "output": "",
+                                                   "error": "nesting_depth_exceeded",
+                                                   "attempts": 0, "verified": None}
+                        continue
+                    child = self.graph_loader(node.workflow_slug) if self.graph_loader else None
+                    if child is None or child.revision != node.workflow_revision:
+                        state["nodes"][node.id] = {"status": "FAILED", "output": "",
+                                                   "error": "nested_revision_mismatch",
+                                                   "attempts": 0, "verified": None}
+                        continue
+
+            batch = [x for x in runnable if x.kind != "workflow_call"
+                     or state["nodes"].get(x.id, {}).get("status") != "FAILED"]
+            for index in range(0, len(batch), policy.max_parallel):
+                chunk = batch[index:index + policy.max_parallel]
+                for node in chunk:
+                    await _emit({"type": "step_start", "i": node.metadata.get("legacy_index", 0),
+                                 "node": node.id, "agent": node.agent,
+                                 "task": self._interpolate(node, state, graph)})
+                results = await asyncio.gather(*[
+                    self._run_node(node, state, graph, executor, policy) for node in chunk
+                ], return_exceptions=True)
+                for node, result in zip(chunk, results):
+                    if isinstance(result, BaseException):
+                        result = {"status": "FAILED", "output": "",
+                                  "error": f"node_error:{type(result).__name__}"}
+                    state["nodes"][node.id] = {
+                        "status": result["status"], "output": result.get("output") or "",
+                        "attempts": _int(result.get("attempts"), 1),
+                        "verified": result.get("verified"), "error": result.get("error") or "",
+                    }
+                    if result["status"] == "COMPLETED":
+                        completed.append(node.id)
+                    await _emit({"type": "step_done",
+                                 "i": node.metadata.get("legacy_index", 0),
+                                 "node": node.id, "agent": node.agent,
+                                 "output": result.get("output") or "",
+                                 "verified": result.get("verified")})
+                # Checkpoint sau MỖI lô, trước khi chạy lô kế: tiến trình chết ở đây
+                # thì resume không mất phần đã xong.
+                self._checkpoint(trace, state)
+
+        output_entry = state["nodes"].get(graph.output_node_id) or {}
+        failed = [nid for nid, item in state["nodes"].items() if item.get("status") == "FAILED"]
+        state["output"] = str(output_entry.get("output") or "")
+        state["status"] = "FAILED" if failed else "COMPLETED"
+        state["stop_reason"] = "node_failed" if failed else "objective_satisfied"
+        state["pending_node_id"] = ""
+        self._checkpoint(trace, state)
+        await _emit({"type": "done", "result": state["output"]})
+        return WorkflowRunResult(
+            state["status"], state["output"], state["stop_reason"],
+            getattr(trace, "task_id", ""), tuple(completed), tuple(reused), "", events)
+
+    async def resume(self, trace, task_id: str, graph: WorkflowGraph, executor: NodeExecutor,
+                     emit: Callable[[dict], Awaitable[None]] | None = None,
+                     confirmed_node_id: str = "") -> WorkflowRunResult:
+        """Chạy tiếp từ checkpoint. Node đã COMPLETED giữ nguyên, không gọi lại executor."""
+        state = self.load_state(task_id)
+        if state is None:
+            return WorkflowRunResult("FAILED", stop_reason="workflow_state_unavailable",
+                                     task_id=task_id)
+        pending = state.get("pending_node_id") or ""
+        if pending:
+            if confirmed_node_id != pending:
+                # Không có xác nhận đúng node thì vẫn đứng yên, không tự đi tiếp.
+                return WorkflowRunResult("WAITING_USER", state.get("output") or "",
+                                         state.get("stop_reason") or "wait_user_node",
+                                         task_id, pending_node_id=pending)
+            node = graph.node(pending)
+            if node is not None and node.kind == "wait_user":
+                state["nodes"][pending] = {
+                    "status": "COMPLETED", "output": state.get("input") or "",
+                    "attempts": 1, "verified": True, "error": "",
+                }
+            state["pending_node_id"] = ""
+            state["status"] = "RUNNING"
+        return await self.run(trace, graph, state.get("input") or "",
+                              state.get("session_id") or "", executor, emit,
+                              resume_state=state, depth=_int(state.get("depth"), 0))

--- a/tests/python/test_workflow_graph_phase10.py
+++ b/tests/python/test_workflow_graph_phase10.py
@@ -429,7 +429,6 @@ def _brain_with_workflow(tmp_path, monkeypatch, settings):
     monkeypatch.setattr(main.system_sync, "ensure_synced", lambda *a, **k: None)
     monkeypatch.setattr(main.system_sync, "mirror_skills", lambda *a, **k: None)
     monkeypatch.setattr(main.cfgmod, "read_settings", lambda: settings)
-    monkeypatch.setattr(main, "_WORKFLOW_CANARY", None)
     return main, brain, calls
 
 
@@ -515,6 +514,55 @@ def test_workflow_source_exposes_manifest_without_node_bodies(tmp_path, monkeypa
     # Thân prompt của node KHÔNG được lọt vào manifest.
     blob = json.dumps(item, ensure_ascii=False)
     assert "Tìm {{input}}" not in blob and "Viết từ" not in blob
+
+
+def test_failure_after_events_does_not_run_the_workflow_twice(tmp_path, monkeypatch):
+    """Lỗi giữa chừng KHÔNG được kéo theo một lượt legacy đầy đủ nữa."""
+    import copy
+    import config as cfgmod
+
+    on = copy.deepcopy(cfgmod._DEFAULT)
+    on["context_runtime"]["mode"] = "canary"
+    on["context_runtime"]["workflow_canary"].update(
+        {"allocation_basis_points": 10_000, "allowed_slugs": ["demo"]})
+    main, brain, calls = _brain_with_workflow(tmp_path, monkeypatch, on)
+
+    async def half_then_boom(brain_, slug, input_="", tools=None, session_id=""):
+        yield {"type": "start", "workflow": "Demo", "steps": 2}
+        yield {"type": "step_done", "node": "s0", "output": "KQ(1)"}
+        raise RuntimeError("đứt giữa chừng")
+
+    monkeypatch.setattr(main, "execute_workflow_graph", half_then_boom)
+    events = _drain(main.execute_workflow("brain", "demo", input="x", session_id="s"))
+    assert not calls, "không được chạy lại bằng runner cũ sau khi đã phát event"
+    assert events[-1]["type"] == "error"
+
+
+def test_each_brain_loads_its_own_nested_workflows(tmp_path, monkeypatch):
+    """graph_loader ôm ĐỊNH DANH brain, nên một canary dùng chung sẽ nạp nhầm brain.
+
+    Test phải để `_workflows_dir` TÔN TRỌNG tham số brain, nếu không nó chỉ đo lại
+    chính cái monkeypatch của mình chứ không đo sự cô lập giữa các brain.
+    """
+    import main
+
+    roots = {}
+    for name, task in (("brain-a", "A {{input}}"), ("brain-b", "B {{input}}")):
+        root = tmp_path / name
+        (root / "workflows").mkdir(parents=True)
+        (root / "workflows" / "demo.md").write_text(
+            f"---\ntype: workflow\nname: {name}\nslug: demo\nstatus: active\n"
+            f"steps:\n  - agent: researcher\n    task: '{task}'\n---\n",
+            encoding="utf-8")
+        roots[name] = root
+
+    monkeypatch.setattr(main, "_workflows_dir", lambda b: roots[b] / "workflows")
+
+    a = main._get_workflow_canary("brain-a").graph_loader("demo")
+    b = main._get_workflow_canary("brain-b").graph_loader("demo")
+    assert a is not None and b is not None
+    assert a.name == "brain-a" and b.name == "brain-b"
+    assert a.revision != b.revision, "mỗi brain phải ra đồ thị của chính nó"
 
 
 if __name__ == "__main__":

--- a/tests/python/test_workflow_graph_phase10.py
+++ b/tests/python/test_workflow_graph_phase10.py
@@ -1,0 +1,500 @@
+"""Phase 10: workflow như capability graph, có checkpoint và resume.
+
+Trọng tâm là ba bất biến: workflow cũ chạy tương đương qua adapter, node đã xong
+không chạy lại sau restart, và node ghi không bao giờ tự chạy.
+"""
+from _paths import SERVER  # noqa: E402,F401
+
+import asyncio
+import json
+
+from cryptography.fernet import Fernet
+
+import workflow_graph as wg
+from context_runtime import ObserveRuntime
+from workflow_runtime import WorkflowCanary, WorkflowPolicy
+
+
+def _crypto():
+    fernet = Fernet(Fernet.generate_key())
+    return (lambda v: "enc:" + fernet.encrypt(v.encode()).decode(),
+            lambda v: fernet.decrypt(v[4:].encode()).decode())
+
+
+def _settings(allocation=10_000, slugs=("demo",), allow_write=False, parallel=3):
+    return {
+        "context_runtime": {
+            "mode": "canary",
+            "workflow_canary": {
+                "policy_version": "test-workflow-v1",
+                "allocation_basis_points": allocation,
+                "allowed_slugs": list(slugs),
+                "max_parallel": parallel,
+                "allow_write_nodes": allow_write,
+                "max_nesting_depth": 1,
+            },
+        }
+    }
+
+
+LEGACY = {
+    "name": "Nghiên cứu rồi viết", "status": "active",
+    "steps": [
+        {"agent": "researcher", "task": "Tìm hiểu {{input}}"},
+        {"agent": "writer", "task": "Viết bài từ: {{prev}}", "verify_agent": "editor",
+         "max_retries": 2},
+    ],
+}
+
+
+def _stack(tmp_path, settings=None, graph_loader=None):
+    settings = settings or _settings()
+    crypto = _crypto()
+    runtime = ObserveRuntime(tmp_path / "rt", settings_reader=lambda: settings)
+    canary = WorkflowCanary(runtime, lambda: settings, graph_loader,
+                            state_encryptor=crypto[0], state_decryptor=crypto[1])
+    return runtime, canary, settings, crypto
+
+
+def _executor(calls, outputs=None, fail_on=()):
+    async def run(node, prompt):
+        calls.append({"node": node.id, "agent": node.agent, "prompt": prompt})
+        if node.id in fail_on:
+            return {"error": "boom", "output": ""}
+        return {"output": (outputs or {}).get(node.id, f"out-{node.id}"), "verified": True}
+    return run
+
+
+# ----------------------------------------------------------------- adapter cũ
+
+def test_legacy_adapter_preserves_shape_and_string_semantics():
+    graph = wg.compile_workflow(LEGACY, "demo")
+    assert graph.adapter == wg.LEGACY_ADAPTER_VERSION
+    assert [x.id for x in graph.nodes] == ["s0", "s1"]
+    # Chuỗi thẳng: mỗi bước phụ thuộc đúng bước trước.
+    assert graph.nodes[0].depends_on == () and graph.nodes[1].depends_on == ("s0",)
+    # Giữ nguyên bốn trường của định dạng cũ.
+    assert graph.nodes[1].verify_agent == "editor" and graph.nodes[1].max_retries == 2
+    # Output vẫn chỉ là bước cuối, đúng như runner cũ.
+    assert graph.output_node_id == "s1"
+    # Hợp đồng là SUY RA, không phải đọc được từ file.
+    assert graph.input_contract["derived"] and graph.output_contract["derived"]
+    assert graph.max_risk == "none" and graph.resumable
+
+
+def test_revision_is_content_addressed_and_stable():
+    first = wg.compile_workflow(LEGACY, "demo")
+    assert wg.compile_workflow(LEGACY, "demo").revision == first.revision
+    changed = json.loads(json.dumps(LEGACY))
+    changed["steps"][0]["task"] = "Tìm hiểu kỹ hơn {{input}}"
+    assert wg.compile_workflow(changed, "demo").revision != first.revision
+    # Đổi thứ mô tả thuần tuý thì đồ thị không đổi.
+    cosmetic = {**LEGACY, "description": "mô tả mới"}
+    assert wg.compile_workflow(cosmetic, "demo").revision == first.revision
+
+
+def test_interpolation_matches_legacy_runner(tmp_path):
+    runtime, canary, settings, _ = _stack(tmp_path)
+    graph = wg.compile_workflow(LEGACY, "demo")
+    trace = runtime.start_turn("sid-wf", str(tmp_path), "dashboard")
+    assert canary.prepare(trace, graph, "sid-wf").action == "execute"
+    calls = []
+    result = asyncio.run(canary.run(
+        trace, graph, "thị trường cà phê", "sid-wf", _executor(calls)))
+    assert result.status == "COMPLETED"
+    # {{input}} vào bước đầu, {{prev}} là output bước trước - đúng ngữ nghĩa cũ.
+    assert calls[0]["prompt"] == "Tìm hiểu thị trường cà phê"
+    assert calls[1]["prompt"] == "Viết bài từ: out-s0"
+    assert result.output == "out-s1"
+
+
+# ----------------------------------------------------------------- DAG
+
+def test_independent_nodes_run_in_one_layer(tmp_path):
+    native = {"name": "song song", "nodes": [
+        {"id": "a", "kind": "model_step", "agent": "x", "task": "A"},
+        {"id": "b", "kind": "model_step", "agent": "y", "task": "B"},
+        {"id": "c", "kind": "model_step", "agent": "z", "task": "C", "depends_on": ["a", "b"]},
+    ]}
+    graph = wg.compile_workflow(native, "demo")
+    assert graph.execution_layers() == (("a", "b"), ("c",))
+
+    runtime, canary, *_ = _stack(tmp_path)
+    trace = runtime.start_turn("sid-par", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-par")
+    active = {"now": 0, "max": 0}
+
+    async def run(node, prompt):
+        active["now"] += 1
+        active["max"] = max(active["max"], active["now"])
+        await asyncio.sleep(0.02)
+        active["now"] -= 1
+        return {"output": f"out-{node.id}"}
+
+    result = asyncio.run(canary.run(trace, graph, "x", "sid-par", run))
+    assert result.status == "COMPLETED" and active["max"] == 2
+
+
+def test_failed_dependency_skips_dependents_without_running_them(tmp_path):
+    native = {"name": "chuỗi", "nodes": [
+        {"id": "a", "kind": "model_step", "agent": "x", "task": "A"},
+        {"id": "b", "kind": "model_step", "agent": "y", "task": "B", "depends_on": ["a"]},
+    ]}
+    graph = wg.compile_workflow(native, "demo")
+    runtime, canary, *_ = _stack(tmp_path)
+    trace = runtime.start_turn("sid-fail", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-fail")
+    calls = []
+    result = asyncio.run(canary.run(
+        trace, graph, "x", "sid-fail", _executor(calls, fail_on=("a",))))
+    assert result.status == "FAILED"
+    assert [x["node"] for x in calls] == ["a"], "node phụ thuộc không được chạy"
+
+
+# ----------------------------------------------------------------- resume
+
+def test_resume_does_not_rerun_completed_nodes(tmp_path):
+    native = {"name": "ba bước", "nodes": [
+        {"id": "a", "kind": "model_step", "agent": "x", "task": "A"},
+        {"id": "b", "kind": "model_step", "agent": "y", "task": "B", "depends_on": ["a"]},
+        {"id": "c", "kind": "model_step", "agent": "z", "task": "C", "depends_on": ["b"]},
+    ]}
+    graph = wg.compile_workflow(native, "demo")
+    settings = _settings()
+    crypto = _crypto()
+    runtime = ObserveRuntime(tmp_path / "rt", settings_reader=lambda: settings)
+    canary = WorkflowCanary(runtime, lambda: settings, None,
+                            state_encryptor=crypto[0], state_decryptor=crypto[1])
+    trace = runtime.start_turn("sid-res", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-res")
+
+    first_calls = []
+
+    async def crash_at_c(node, prompt):
+        first_calls.append(node.id)
+        if node.id == "c":
+            raise RuntimeError("tiến trình chết")
+        return {"output": f"out-{node.id}"}
+
+    first = asyncio.run(canary.run(trace, graph, "x", "sid-res", crash_at_c))
+    assert first.status == "FAILED" and first_calls == ["a", "b", "c"]
+    task_id = trace.task_id
+    runtime.close()
+
+    # Tiến trình mới, cùng file DB.
+    runtime2 = ObserveRuntime(tmp_path / "rt", settings_reader=lambda: settings)
+    canary2 = WorkflowCanary(runtime2, lambda: settings, None,
+                             state_encryptor=crypto[0], state_decryptor=crypto[1])
+    trace2 = runtime2.resume_trace(task_id)
+    second_calls = []
+    second = asyncio.run(canary2.resume(
+        trace2, task_id, graph, _executor(second_calls)))
+    assert second.status == "COMPLETED"
+    assert [x["node"] for x in second_calls] == ["c"], "chỉ node chưa xong mới chạy lại"
+    assert set(second.reused_nodes) == {"a", "b"}
+    # Output của node đã xong được lấy từ checkpoint, không phải chạy lại.
+    assert second_calls[0]["prompt"] == "C"
+
+
+def test_resume_refuses_when_workflow_definition_changed(tmp_path):
+    graph = wg.compile_workflow(LEGACY, "demo")
+    settings = _settings()
+    crypto = _crypto()
+    runtime = ObserveRuntime(tmp_path / "rt", settings_reader=lambda: settings)
+    canary = WorkflowCanary(runtime, lambda: settings, None,
+                            state_encryptor=crypto[0], state_decryptor=crypto[1])
+    trace = runtime.start_turn("sid-chg", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-chg")
+    asyncio.run(canary.run(trace, graph, "x", "sid-chg",
+                           _executor([], fail_on=("s1",))))
+    task_id = trace.task_id
+
+    edited = json.loads(json.dumps(LEGACY))
+    edited["steps"][1]["task"] = "Viết KHÁC HẲN từ {{prev}}"
+    new_graph = wg.compile_workflow(edited, "demo")
+    calls = []
+    result = asyncio.run(canary.resume(
+        runtime.resume_trace(task_id), task_id, new_graph, _executor(calls)))
+    assert result.status == "FAILED"
+    assert result.stop_reason == "workflow_revision_mismatch"
+    assert not calls, "định nghĩa đã đổi thì không được chạy tiếp node nào"
+
+
+# ----------------------------------------------------------------- node ghi
+
+def test_write_node_pauses_and_never_runs_by_itself(tmp_path):
+    native = {"name": "có ghi", "nodes": [
+        {"id": "a", "kind": "model_step", "agent": "x", "task": "soạn"},
+        {"id": "w", "kind": "capability", "capability": "mail_send", "effect": "write",
+         "depends_on": ["a"]},
+    ]}
+    graph = wg.compile_workflow(native, "demo")
+    assert graph.write_node_ids == ("w",) and graph.max_risk == "write"
+
+    # Mặc định workflow có node ghi bị chặn từ cổng admission.
+    runtime, canary, *_ = _stack(tmp_path)
+    trace = runtime.start_turn("sid-w1", str(tmp_path), "dashboard")
+    assert canary.prepare(trace, graph, "sid-w1").reason == "write_nodes_not_enabled"
+
+    # Bật lên thì vẫn chỉ chạy tới node ghi rồi DỪNG hỏi, không tự gọi.
+    runtime2, canary2, *_ = _stack(tmp_path / "b", _settings(allow_write=True))
+    trace2 = runtime2.start_turn("sid-w2", str(tmp_path), "dashboard")
+    assert canary2.prepare(trace2, graph, "sid-w2").action == "execute"
+    calls = []
+    result = asyncio.run(canary2.run(trace2, graph, "x", "sid-w2", _executor(calls)))
+    assert result.status == "WAITING_USER"
+    assert result.pending_node_id == "w"
+    assert result.stop_reason == "write_node_needs_confirmation"
+    assert [x["node"] for x in calls] == ["a"], "node ghi tuyệt đối không được gọi"
+
+
+def test_pending_write_stays_put_without_matching_confirmation(tmp_path):
+    native = {"name": "chờ", "nodes": [
+        {"id": "q", "kind": "wait_user", "prompt": "Duyệt nhé?"},
+        {"id": "b", "kind": "model_step", "agent": "y", "task": "tiếp", "depends_on": ["q"]},
+    ]}
+    graph = wg.compile_workflow(native, "demo")
+    runtime, canary, settings, crypto = _stack(tmp_path)
+    trace = runtime.start_turn("sid-wait", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-wait")
+    first = asyncio.run(canary.run(trace, graph, "x", "sid-wait", _executor([])))
+    assert first.status == "WAITING_USER" and first.pending_node_id == "q"
+    task_id = trace.task_id
+
+    calls = []
+    stuck = asyncio.run(canary.resume(
+        runtime.resume_trace(task_id), task_id, graph, _executor(calls),
+        confirmed_node_id="sai-node"))
+    assert stuck.status == "WAITING_USER" and not calls
+
+    went = asyncio.run(canary.resume(
+        runtime.resume_trace(task_id), task_id, graph, _executor(calls),
+        confirmed_node_id="q"))
+    assert went.status == "COMPLETED"
+    assert [x["node"] for x in calls] == ["b"]
+
+
+# ----------------------------------------------------------------- workflow con
+
+def test_nested_workflow_requires_pinned_revision(tmp_path):
+    child_meta = {"name": "con", "steps": [{"agent": "a", "task": "làm"}]}
+    child = wg.compile_workflow(child_meta, "con")
+    parent = {"name": "cha", "nodes": [
+        {"id": "n", "kind": "workflow_call", "workflow": "con",
+         "workflow_revision": child.revision},
+    ]}
+    graph = wg.compile_workflow(parent, "demo")
+    assert graph.nested_slugs == ("con",)
+
+    # Workflow con bị sửa -> revision lệch -> node hỏng, không chạy nhầm bản mới.
+    edited = {**child_meta, "steps": [{"agent": "a", "task": "làm khác"}]}
+    stale = wg.compile_workflow(edited, "con")
+    runtime, canary, *_ = _stack(tmp_path, graph_loader=lambda slug: stale)
+    trace = runtime.start_turn("sid-n", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-n")
+    result = asyncio.run(canary.run(trace, graph, "x", "sid-n", _executor([])))
+    assert result.status == "FAILED"
+
+
+def test_graph_validation_rejects_every_malformed_shape():
+    """Từng luật một, có case riêng - để gỡ luật nào ra là đỏ luật đó."""
+    cases = {
+        "nested_workflow_without_revision": {"nodes": [
+            {"id": "n", "kind": "workflow_call", "workflow": "con"}]},
+        "effect_not_allowed": {"nodes": [
+            {"id": "n", "kind": "capability", "capability": "rm", "effect": "dangerous"}]},
+        "duplicate_node_id": {"nodes": [
+            {"id": "a", "kind": "model_step", "agent": "x"},
+            {"id": "a", "kind": "model_step", "agent": "y"}]},
+        "unknown_or_forward_dependency": {"nodes": [
+            {"id": "a", "kind": "model_step", "agent": "x", "depends_on": ["b"]},
+            {"id": "b", "kind": "model_step", "agent": "y"}]},
+        "unknown_node_kind": {"nodes": [{"id": "a", "kind": "bịa ra"}]},
+        "model_step_without_agent": {"nodes": [
+            {"id": "a", "kind": "model_step", "task": "x"}]},
+        "capability_node_without_target": {"nodes": [
+            {"id": "a", "kind": "capability", "effect": "read"}]},
+        "compensation_for_unknown_node": {"nodes": [
+            {"id": "c", "kind": "compensation", "compensates": "không có"}]},
+        "workflow_has_no_nodes": {"nodes": []},
+        "invalid_node_id": {"nodes": [{"id": "id có dấu cách", "kind": "model_step",
+                                       "agent": "x"}]},
+    }
+    for expected, meta in cases.items():
+        try:
+            wg.compile_workflow(meta, "demo")
+        except wg.WorkflowContractError as exc:
+            assert expected in str(exc), (expected, str(exc))
+        else:
+            raise AssertionError(f"phải từ chối: {expected}")
+
+    # Slug workflow cũng phải hợp lệ.
+    try:
+        wg.compile_workflow(LEGACY, "Slug Sai")
+    except wg.WorkflowContractError as exc:
+        assert "invalid_workflow_slug" in str(exc)
+    else:
+        raise AssertionError("slug sai phải bị từ chối")
+
+    # Bước cũ thiếu agent cũng không được lọt qua adapter.
+    try:
+        wg.compile_workflow({"steps": [{"task": "không có agent"}]}, "demo")
+    except wg.WorkflowContractError as exc:
+        assert "legacy_step_without_agent" in str(exc)
+    else:
+        raise AssertionError("bước cũ thiếu agent phải bị từ chối")
+
+
+# ----------------------------------------------------------------- mặc định tắt
+
+def test_defaults_do_not_admit_any_workflow(tmp_path):
+    import copy
+    import config as cfgmod
+
+    settings = copy.deepcopy(cfgmod._DEFAULT)
+    policy = WorkflowPolicy.from_settings(settings)
+    assert policy.allocation_basis_points == 0
+    assert policy.allowed_slugs == ()
+    assert policy.allow_write_nodes is False
+    admitted, _bucket, reason = policy.admits("demo", "bất kỳ session nào")
+    assert not admitted and reason == "mode_not_canary"
+
+    runtime = ObserveRuntime(tmp_path / "rt", settings_reader=lambda: settings)
+    canary = WorkflowCanary(runtime, lambda: settings)
+    trace = runtime.start_turn("sid-def", str(tmp_path), "dashboard")
+    graph = wg.compile_workflow(LEGACY, "demo")
+    assert canary.prepare(trace, graph, "sid-def").action == "legacy"
+
+
+# ------------------------------------------- tích hợp qua main.execute_workflow
+
+def _brain_with_workflow(tmp_path, monkeypatch, settings):
+    """Dựng một brain thật có workflow + agent để chạy qua đúng main.execute_workflow."""
+    import main
+
+    brain = tmp_path / "brain"
+    (brain / "workflows").mkdir(parents=True)
+    (brain / "agents").mkdir(parents=True)
+    (brain / "workflows" / "demo.md").write_text(
+        "---\n"
+        "type: workflow\nname: Demo\nslug: demo\nstatus: active\n"
+        "steps:\n"
+        "  - agent: researcher\n    task: 'Tìm {{input}}'\n"
+        "  - agent: writer\n    task: 'Viết từ {{prev}}'\n"
+        "---\n", encoding="utf-8")
+    for slug in ("researcher", "writer"):
+        (brain / "agents" / f"{slug}.md").write_text(
+            f"---\ntype: agent\nname: {slug}\nslug: {slug}\nrole: r\nskills: []\n---\nthân\n",
+            encoding="utf-8")
+
+    calls = []
+
+    class FakeEngine:
+        def __init__(self, *a, **k):
+            self.model = None
+
+        async def query(self, prompt):
+            calls.append(prompt)
+            yield {"type": "final", "content": f"KQ({len(calls)})"}
+
+    monkeypatch.setattr(main, "claude_engine", lambda **k: FakeEngine())
+    monkeypatch.setattr(main, "_brain_root", lambda b: str(brain))
+    monkeypatch.setattr(main, "_workflows_dir", lambda b: brain / "workflows")
+    monkeypatch.setattr(main, "_agents_dir", lambda b: brain / "agents")
+    monkeypatch.setattr(main, "_agent_memory", lambda b, s: "")
+    monkeypatch.setattr(main, "_log_agent_run", lambda *a, **k: None)
+    monkeypatch.setattr(main.system_sync, "ensure_synced", lambda *a, **k: None)
+    monkeypatch.setattr(main.system_sync, "mirror_skills", lambda *a, **k: None)
+    monkeypatch.setattr(main.cfgmod, "read_settings", lambda: settings)
+    monkeypatch.setattr(main, "_WORKFLOW_CANARY", None)
+    return main, brain, calls
+
+
+def _drain(gen):
+    async def go():
+        return [x async for x in gen]
+    return asyncio.run(go())
+
+
+def test_graph_path_and_legacy_runner_agree(tmp_path, monkeypatch):
+    """Bất biến của spec: workflow hiện tại chạy TƯƠNG ĐƯƠNG qua adapter."""
+    import copy
+    import config as cfgmod
+
+    # Đường cũ: mặc định repo (allocation 0).
+    off = copy.deepcopy(cfgmod._DEFAULT)
+    main, brain, legacy_calls = _brain_with_workflow(tmp_path / "a", monkeypatch, off)
+    legacy_events = _drain(main.execute_workflow("brain", "demo", input="cà phê"))
+    legacy_result = [x for x in legacy_events if x["type"] == "done"][0]["result"]
+
+    # Đường mới: bật canary cho đúng slug này.
+    on = copy.deepcopy(cfgmod._DEFAULT)
+    on["context_runtime"]["mode"] = "canary"
+    on["context_runtime"]["workflow_canary"].update(
+        {"allocation_basis_points": 10_000, "allowed_slugs": ["demo"]})
+    main2, brain2, graph_calls = _brain_with_workflow(tmp_path / "b", monkeypatch, on)
+    graph_events = _drain(
+        main2.execute_workflow("brain", "demo", input="cà phê", session_id="s1"))
+    graph_result = [x for x in graph_events if x["type"] == "done"][0]["result"]
+
+    # Cùng prompt gửi cho agent, cùng kết quả cuối.
+    assert legacy_calls == graph_calls == ["Tìm cà phê", "Viết từ KQ(1)"]
+    assert legacy_result == graph_result == "KQ(2)"
+    # Đường mới vẫn phát bộ event dashboard đang nghe.
+    assert {"start", "step_start", "step_done", "done"} <= {x["type"] for x in graph_events}
+
+
+def test_repo_defaults_keep_workflows_on_the_legacy_runner(tmp_path, monkeypatch):
+    import copy
+    import config as cfgmod
+
+    settings = copy.deepcopy(cfgmod._DEFAULT)
+    main, brain, calls = _brain_with_workflow(tmp_path, monkeypatch, settings)
+    events = _drain(main.execute_workflow("brain", "demo", input="x", session_id="s"))
+    assert [x["type"] for x in events][0] == "start"
+    # Đường graph gắn thêm "node" vào step_done; runner cũ thì không.
+    assert all("node" not in x for x in events if x["type"] == "step_done")
+    assert calls == ["Tìm x", "Viết từ KQ(1)"]
+
+
+def test_graph_failure_falls_back_to_legacy_runner(tmp_path, monkeypatch):
+    """Lỗi ở đường mới không được cướp lượt chạy của người dùng."""
+    import copy
+    import config as cfgmod
+
+    on = copy.deepcopy(cfgmod._DEFAULT)
+    on["context_runtime"]["mode"] = "canary"
+    on["context_runtime"]["workflow_canary"].update(
+        {"allocation_basis_points": 10_000, "allowed_slugs": ["demo"]})
+    main, brain, calls = _brain_with_workflow(tmp_path, monkeypatch, on)
+
+    def boom(*a, **k):
+        raise RuntimeError("đường graph hỏng")
+
+    monkeypatch.setattr(main, "execute_workflow_graph", boom)
+    events = _drain(main.execute_workflow("brain", "demo", input="x", session_id="s"))
+    assert [x for x in events if x["type"] == "done"][0]["result"] == "KQ(2)"
+    assert calls == ["Tìm x", "Viết từ KQ(1)"]
+
+
+def test_workflow_source_exposes_manifest_without_node_bodies(tmp_path, monkeypatch):
+    import copy
+    import config as cfgmod
+
+    main, brain, _ = _brain_with_workflow(
+        tmp_path, monkeypatch, copy.deepcopy(cfgmod._DEFAULT))
+    manifests = main.workflow_manifests("brain")
+    assert len(manifests) == 1
+    item = manifests[0]
+    assert item["slug"] == "demo" and item["node_count"] == 2
+    assert item["max_risk"] == "none" and item["resumable"] is True
+    assert item["input_contract"]["derived"] and item["output_contract"]["derived"]
+    # Thân prompt của node KHÔNG được lọt vào manifest.
+    blob = json.dumps(item, ensure_ascii=False)
+    assert "Tìm {{input}}" not in blob and "Viết từ" not in blob
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/python/test_workflow_graph_phase10.py
+++ b/tests/python/test_workflow_graph_phase10.py
@@ -389,6 +389,38 @@ def test_confirming_a_write_node_reports_instead_of_pausing_forever(tmp_path):
     assert not calls, "vẫn tuyệt đối không gọi tool ghi"
 
 
+def test_checkpoint_failure_stops_instead_of_running_on(tmp_path):
+    """Checkpoint hỏng thường là do tiến trình khác đã resume cùng task.
+
+    Đi tiếp lúc đó là hai bên cùng chạy một node, tức là gọi model hai lần.
+    """
+    native = {"name": "ba bước", "nodes": [
+        {"id": "a", "kind": "model_step", "agent": "x", "task": "A"},
+        {"id": "b", "kind": "model_step", "agent": "y", "task": "B", "depends_on": ["a"]},
+        {"id": "c", "kind": "model_step", "agent": "z", "task": "C", "depends_on": ["b"]},
+    ]}
+    graph = wg.compile_workflow(native, "demo")
+    runtime, canary, *_ = _stack(tmp_path)
+    trace = runtime.start_turn("sid-cp", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-cp")
+
+    real = canary._checkpoint
+    seen = {"n": 0}
+
+    def flaky(tr, state, initialize=False):
+        if initialize:
+            return real(tr, state, initialize=True)
+        seen["n"] += 1
+        return False if seen["n"] >= 1 else real(tr, state)
+
+    canary._checkpoint = flaky
+    calls = []
+    result = asyncio.run(canary.run(trace, graph, "x", "sid-cp", _executor(calls)))
+    assert result.status == "FAILED" and result.stop_reason == "checkpoint_failed"
+    # Dừng ngay sau lô đầu, không chạy nốt b và c.
+    assert [x["node"] for x in calls] == ["a"]
+
+
 # ------------------------------------------- tích hợp qua main.execute_workflow
 
 def _brain_with_workflow(tmp_path, monkeypatch, settings):

--- a/tests/python/test_workflow_graph_phase10.py
+++ b/tests/python/test_workflow_graph_phase10.py
@@ -366,6 +366,29 @@ def test_defaults_do_not_admit_any_workflow(tmp_path):
     assert canary.prepare(trace, graph, "sid-def").action == "legacy"
 
 
+def test_confirming_a_write_node_reports_instead_of_pausing_forever(tmp_path):
+    """Người dùng đã đồng ý mà workflow cứ dừng lại mãi là hành vi dối trá."""
+    native = {"name": "có ghi", "nodes": [
+        {"id": "a", "kind": "model_step", "agent": "x", "task": "soạn"},
+        {"id": "w", "kind": "capability", "capability": "mail_send", "effect": "write",
+         "depends_on": ["a"]},
+    ]}
+    graph = wg.compile_workflow(native, "demo")
+    runtime, canary, *_ = _stack(tmp_path, _settings(allow_write=True))
+    trace = runtime.start_turn("sid-wc", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-wc")
+    first = asyncio.run(canary.run(trace, graph, "x", "sid-wc", _executor([])))
+    assert first.status == "WAITING_USER" and first.pending_node_id == "w"
+
+    calls = []
+    confirmed = asyncio.run(canary.resume(
+        runtime.resume_trace(trace.task_id), trace.task_id, graph,
+        _executor(calls), confirmed_node_id="w"))
+    assert confirmed.status == "WAITING_USER"
+    assert confirmed.stop_reason == "write_execution_not_enabled_in_this_phase"
+    assert not calls, "vẫn tuyệt đối không gọi tool ghi"
+
+
 # ------------------------------------------- tích hợp qua main.execute_workflow
 
 def _brain_with_workflow(tmp_path, monkeypatch, settings):


### PR DESCRIPTION
Runner workflow hiện tại là một vòng lặp tuần tự 145 dòng **không có trạng thái**. Task Kanban chạy workflow mà tiến trình chết là chạy lại từ bước 0, kể cả những bước đã ghi ra ngoài. Phase 10 bọc đúng định dạng cũ vào cỗ máy đồ thị + checkpoint của runtime mới.

Mặc định repository KHÔNG đổi hành vi: `workflow_canary.allocation_basis_points = 0`, `allowed_slugs = []` (fail-closed). Mọi workflow tiếp tục chạy bằng runner cũ.

## Tương đương là do dùng chung code, không phải do chép cho giống

Yêu cầu của spec là "workflow hiện tại chạy tương đương qua adapter". Cách bảo đảm: tách phần chạy MỘT bước (agent, kiểm chứng, retry evaluator-optimizer) thành `_run_workflow_step`, rồi cho **cả runner cũ lẫn đường graph gọi chung nó**. Sửa gì ở đó tự động áp cho cả hai, không có đường nào lệch đi được.

Có test chạy cùng một workflow qua cả hai đường và so từng prompt gửi cho agent lẫn kết quả cuối.

## Bất biến, và cách kiểm chứng

Mọi hàng rào dưới đây đều được kiểm chứng bằng cách **gỡ nó ra xem test có đỏ không**. Đây là phản ứng trực tiếp với phát hiện ở PR trước: 100 test của Phase 0-8 xanh suốt tám phase mà chưa từng chạy, nên một test xanh tự nó không chứng minh gì.

| Bất biến | Gỡ hàng rào ra |
|---|---|
| Node đã xong không chạy lại sau restart | đỏ |
| Node ghi không bao giờ tự chạy (dừng `WAITING_USER`) | đỏ |
| Xác nhận node ghi thì báo rõ, không dừng vô hạn | đỏ |
| Resume từ chối khi định nghĩa workflow đã đổi | đỏ |
| Workflow con bắt buộc ghim revision | đỏ |
| Mỗi brain nạp workflow con của chính nó | đỏ |
| Đứt giữa chừng không kéo theo lượt legacy thứ hai | đỏ |
| Checkpoint hỏng thì dừng, không chạy tiếp | đỏ |
| Từng luật validate đồ thị (10 luật) | đỏ |

## Bốn lỗi tự tìm ra khi soát lại

Cả bốn thuộc cùng một họ: đường đi hiếm gặp mà ở đó hệ thống làm một việc **hai lần** hoặc **im lặng không làm gì**. Đúng họ lỗi mà runner không trạng thái không thể có, còn runner có trạng thái thì phải trả giá để canh.

1. **Dừng vô hạn.** Người dùng xác nhận node ghi thì resume xoá cờ chờ rồi chạy tiếp, nhưng node đó vẫn chưa xong nên lại dừng - mãi mãi, im lặng. Nay báo rõ rằng thực thi node ghi thuộc phase sau.
2. **Rò rỉ xuyên brain.** Canary cache toàn cục nhưng hàm nạp workflow con ôm định danh brain của lần gọi đầu tiên; brain thứ hai sẽ nạp workflow con từ brain sai.
3. **Chạy hai lần.** Lỗi sau khi đã phát event ra client vẫn rơi xuống runner cũ, nên client thấy một phần lượt mới rồi thêm nguyên một lượt cũ nữa.
4. **Checkpoint hỏng vẫn đi tiếp.** Checkpoint hỏng hầu như luôn là do hai tiến trình cùng resume một task; đi tiếp là cả hai cùng chạy một node.

Test đầu tiên cho lỗi 2 viết sai (helper monkeypatch `_workflows_dir` bỏ qua tham số brain, nên nó chỉ đo lại chính cái monkeypatch). Phát hiện vì gỡ bản vá ra mà test vẫn xanh. Đã viết lại.

## Câu hỏi mục 30.3 ý 5 đã có câu trả lời

Workflow hiện tại **không có hợp đồng dữ liệu nào cả**: bốn trường mỗi bước, truyền dữ liệu bằng thay chuỗi `{{prev}}`, chỉ output bước cuối quan sát được. Nên adapter phải **tự suy ra** hợp đồng chứ không đọc được từ file, và hợp đồng suy ra được đánh dấu `derived: true` để không ai nhầm nó là thứ tác giả workflow đã khai.

Giữ nguyên hành vi cũ: một chuỗi vào, chuỗi của bước cuối đi ra. Làm output giàu hơn là **đổi hành vi**, không phải di trú - để lại cho một thay đổi riêng có canary riêng.

## WorkflowSource

Workflow vào Registry với kind `workflow`, chỉ metadata + hợp đồng, **không kèm thân prompt của node** (có test khẳng định). Resolver hard-filter kind này khỏi đường chọn tool, nên thêm workflow không làm prompt đầu nạp to ra. Phần thân chung của skill và workflow gộp thành `_refresh_derived_kind`.

Đã kiểm tra đường nâng cấp trên database dựng bằng code cũ: tool và skill giữ nguyên, workflow thêm vào, không sinh source trùng, `integrity_check` báo ok.

## Ngoài phạm vi phase này

Node `capability` và `workflow_call` mới được validate và checkpoint, chưa được tự thực thi. Đường graph hiện chỉ tự chạy `model_step`. Effect `dangerous` bị từ chối biên dịch trong mọi cấu hình.

## Kiểm thử

20 test mới cho Phase 10. Toàn bộ test Python chạy theo đúng cách CI chạy: pass, trừ `test_fastyaml.py` đỏ vì container thiếu libyaml (môi trường, không phải code). Test JS pass.