### PR TITLE
Adaptive Runtime v2 Phase 11: agent tự lập lại kế hoạch trong đúng quyền đã cấp

### DIFF
--- a/docs/dev/2026-08-adaptive-context-runtime-spec.md
+++ b/docs/dev/2026-08-adaptive-context-runtime-spec.md
@@ -1936,6 +1936,33 @@ Rollback: workflow mới trở về runner hiện tại; task workflow đang ch�
 
 ### Phase 11: Agent replanning
 
+Trạng thái code ngày 2026-08-02: **hoàn tất, chưa bật production**. `agent_canary` mặc định
+allocation `0` và `allowed_slugs` rỗng. Workflow chỉ được replan khi TỰ KHAI `agent: true`
+trong frontmatter; workflow thường giữ đồ thị cố định của Phase 10.
+
+Bất biến trung tâm, và cũng là thứ dễ hỏng nhất:
+
+> **Replan không bao giờ được cấp thêm quyền.**
+
+Tập quyền (`CapabilityGrant`) được ghim từ đồ thị GỐC lúc khởi tạo: agent nào được gọi,
+capability nào được dùng, có được ghi hay không. Node do model đề xuất phải nằm trọn trong
+tập đó. Model không thể mở rộng quyền của chính nó bằng cách đề xuất kế hoạch mới - đây là
+lý do phép kiểm nằm trong code chứ không nằm trong prompt (mục 4.4).
+
+Ba điểm thiết kế đáng ghi lại:
+
+- **Một node xấu chặn cả lô.** Kế hoạch có node vượt quyền thì dừng toàn bộ vòng, không
+  lặng lẽ bỏ node đó rồi chạy phần còn lại - chạy một nửa kế hoạch của model là hành vi
+  không ai suy luận được.
+- **Model chỉ được thêm `model_step` và `capability`.** `workflow_call`, `wait_user` và
+  `compensation` là thứ người viết workflow khai, không phải thứ model tự thêm giữa chừng.
+- **Lặp lại cùng dấu vết lỗi thì escalate**, không thử mãi. Dấu vết chỉ gồm node nào hỏng
+  vì lý do gì, không kèm nội dung.
+
+Người lập kế hoạch bằng model chưa được đấu vào: hàm planner mặc định trả rỗng (dừng sạch).
+Nó sẽ được nối khi có gold benchmark chứng minh đường agentic tốt hơn workflow cố định -
+đúng điều kiện qua phase bên dưới.
+
 Thay đổi:
 
 - Agent như workflow có quyền replan trong capability lease và task budget.

--- a/server/agent_runtime.py
+++ b/server/agent_runtime.py
@@ -152,6 +152,9 @@ class AgentRunResult:
     added_node_ids: tuple[str, ...] = ()
     escalation: str = ""
     events: list[dict] = field(default_factory=list)
+    # Output đến từ node nào. Cần thiết vì khi node output cuối hỏng, ta trả kết quả
+    # của node hoàn tất gần nhất - người dùng phải biết mình đang đọc cái gì.
+    output_node_id: str = ""
 
 
 class AgentRunner:
@@ -168,6 +171,22 @@ class AgentRunner:
             return AgentPolicy.from_settings(self.settings_reader() or {})
         except Exception:
             return AgentPolicy.from_settings({})
+
+    @staticmethod
+    def _best_output(state: dict, preferred_node_id: str) -> tuple[str, str]:
+        """Node output ưu tiên; nếu nó rỗng thì lấy node hoàn tất GẦN NHẤT.
+
+        Vòng replan hỏng không được xoá sạch công sức các vòng trước: trả rỗng trong
+        khi đã có kết quả tốt là tệ hơn hẳn việc trả kết quả cũ kèm nói rõ nguồn.
+        """
+        nodes = state.get("nodes") or {}
+        preferred = (nodes.get(preferred_node_id) or {}).get("output") or ""
+        if preferred:
+            return preferred, preferred_node_id
+        for node_id, item in reversed(list(nodes.items())):
+            if (item or {}).get("status") == "COMPLETED" and (item or {}).get("output"):
+                return item["output"], node_id
+        return "", ""
 
     @staticmethod
     def _failure_signature(state: dict) -> str:
@@ -269,16 +288,20 @@ class AgentRunner:
                 # Đây không phải "chưa đạt mục tiêu" mà là runtime nói dừng: checkpoint
                 # hỏng nghĩa là tiến trình khác đang giữ task, revision lệch nghĩa là
                 # định nghĩa đã đổi. Replan lúc này là chạy đè lên người khác.
-                return AgentRunResult("STOPPED", result.output, result.stop_reason,
-                                      result.task_id, rounds, tuple(added), "", events)
+                text, from_node = self._best_output(state or {}, current.output_node_id)
+                return AgentRunResult("STOPPED", text, result.stop_reason,
+                                      result.task_id, rounds, tuple(added), "", events,
+                                      from_node)
             if state is None:
                 return AgentRunResult("FAILED", result.output, "agent_state_unavailable",
                                       result.task_id, rounds, tuple(added), "", events)
 
             decision = self._evaluate(result, state)
             if decision == "pass":
-                return AgentRunResult("COMPLETED", result.output, "objective_satisfied",
-                                      result.task_id, rounds, tuple(added), "", events)
+                text, from_node = self._best_output(state, current.output_node_id)
+                return AgentRunResult("COMPLETED", text, "objective_satisfied",
+                                      result.task_id, rounds, tuple(added), "", events,
+                                      from_node)
 
             signature = self._failure_signature(state)
             if signature:
@@ -286,17 +309,23 @@ class AgentRunner:
                 if seen_signatures[signature] >= policy.failure_repeat_limit:
                     # Lặp lại cùng một lỗi thì thử nữa cũng vô ích. Đưa ra người dùng.
                     await _emit({"type": "escalation", "reason": "repeated_failure_signature"})
+                    text, from_node = self._best_output(state, current.output_node_id)
                     return AgentRunResult(
-                        "ESCALATED", result.output, "repeated_failure_signature",
+                        "ESCALATED", text, "repeated_failure_signature",
                         result.task_id, rounds, tuple(added),
-                        "Agent gặp lại đúng một lỗi nhiều lần nên dừng để anh xem.", events)
+                        "Agent gặp lại đúng một lỗi nhiều lần nên dừng để anh xem.",
+                        events, from_node)
 
             if rounds >= policy.max_replan_rounds:
-                return AgentRunResult("STOPPED", result.output, "replan_budget_exhausted",
-                                      result.task_id, rounds, tuple(added), "", events)
+                text, from_node = self._best_output(state, current.output_node_id)
+                return AgentRunResult("STOPPED", text, "replan_budget_exhausted",
+                                      result.task_id, rounds, tuple(added), "", events,
+                                      from_node)
             if len(current.nodes) >= policy.max_total_nodes:
-                return AgentRunResult("STOPPED", result.output, "node_budget_exhausted",
-                                      result.task_id, rounds, tuple(added), "", events)
+                text, from_node = self._best_output(state, current.output_node_id)
+                return AgentRunResult("STOPPED", text, "node_budget_exhausted",
+                                      result.task_id, rounds, tuple(added), "", events,
+                                      from_node)
 
             summary = {
                 "objective": input_text,
@@ -312,12 +341,16 @@ class AgentRunner:
             try:
                 proposed = await planner(input_text, summary, granted)
             except Exception as exc:
-                return AgentRunResult("STOPPED", result.output,
+                text, from_node = self._best_output(state, current.output_node_id)
+                return AgentRunResult("STOPPED", text,
                                       f"planner_error:{type(exc).__name__}",
-                                      result.task_id, rounds, tuple(added), "", events)
+                                      result.task_id, rounds, tuple(added), "", events,
+                                      from_node)
             if not proposed:
-                return AgentRunResult("STOPPED", result.output, "planner_had_nothing_to_add",
-                                      result.task_id, rounds, tuple(added), "", events)
+                text, from_node = self._best_output(state, current.output_node_id)
+                return AgentRunResult("STOPPED", text, "planner_had_nothing_to_add",
+                                      result.task_id, rounds, tuple(added), "", events,
+                                      from_node)
 
             rounds += 1
             existing = {x.id for x in current.nodes}
@@ -326,13 +359,17 @@ class AgentRunner:
                     list(proposed), grant, existing, rounds, policy)
             except PermissionEscalation as exc:
                 await _emit({"type": "escalation", "reason": str(exc)})
+                text, from_node = self._best_output(state, current.output_node_id)
                 return AgentRunResult(
-                    "ESCALATED", result.output, str(exc), result.task_id,
+                    "ESCALATED", text, str(exc), result.task_id,
                     rounds, tuple(added),
-                    "Kế hoạch mới đòi quyền chưa được cấp nên Javis đã dừng.", events)
+                    "Kế hoạch mới đòi quyền chưa được cấp nên Javis đã dừng.",
+                    events, from_node)
             if len(current.nodes) + len(new_nodes) > policy.max_total_nodes:
-                return AgentRunResult("STOPPED", result.output, "node_budget_exhausted",
-                                      result.task_id, rounds, tuple(added), "", events)
+                text, from_node = self._best_output(state, current.output_node_id)
+                return AgentRunResult("STOPPED", text, "node_budget_exhausted",
+                                      result.task_id, rounds, tuple(added), "", events,
+                                      from_node)
 
             added.extend(x.id for x in new_nodes)
             current = self._extend(current, new_nodes, new_nodes[-1].id)

--- a/server/agent_runtime.py
+++ b/server/agent_runtime.py
@@ -1,0 +1,345 @@
+"""Adaptive Runtime Phase 11: agent = workflow CÓ QUYỀN tự lập lại kế hoạch.
+
+Phase 10 cho workflow một đồ thị cố định. Phase 11 cho phép sau khi chạy xong mà
+Quality Gate chưa hài lòng thì agent được đề xuất thêm node và chạy tiếp - trong
+đúng ngân sách và đúng quyền đã cấp từ đầu.
+
+Bất biến quan trọng nhất của phase này, và cũng là thứ dễ hỏng nhất:
+
+    **Replan KHÔNG BAO GIỜ được cấp thêm quyền.**
+
+Tập capability được ghim lúc khởi tạo. Node do model đề xuất chỉ được dùng lại đúng
+những gì đã có trong tập đó. Model không thể mở rộng quyền của chính nó bằng cách
+đề xuất một kế hoạch mới - đó là lý do việc kiểm tra nằm ở đây, trong code, chứ
+không nằm trong prompt.
+
+Ba đường dừng, không có đường thứ tư: đạt mục tiêu, hết ngân sách, hoặc lặp lại
+cùng một dấu vết lỗi. Trường hợp cuối được escalate ra người dùng thay vì thử mãi.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Optional
+
+import workflow_graph
+from workflow_graph import WorkflowGraph, WorkflowNode
+from workflow_runtime import WorkflowCanary, WorkflowRunResult
+
+AGENT_POLICY_VERSION = "agent-replan-canary-v1"
+
+# Người lập kế hoạch bổ sung: nhận (objective, tóm tắt state, tập quyền đã cấp)
+# và trả danh sách node đề xuất. Trả rỗng nghĩa là "không biết làm gì thêm".
+Planner = Callable[[str, dict, dict], Awaitable[list[dict]]]
+
+
+def _int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return int(default)
+
+
+def _sha(value: Any) -> str:
+    return hashlib.sha256(json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str
+    ).encode("utf-8", errors="replace")).hexdigest()
+
+
+class PermissionEscalation(PermissionError):
+    """Kế hoạch mới đòi quyền chưa được cấp. Luôn dừng, không bao giờ nới ra."""
+
+
+@dataclass(frozen=True)
+class AgentPolicy:
+    mode: str
+    allocation_basis_points: int
+    salt: str
+    allowed_slugs: tuple[str, ...]
+    max_replan_rounds: int
+    max_total_nodes: int
+    max_nodes_per_replan: int
+    failure_repeat_limit: int
+    version: str
+
+    @classmethod
+    def from_settings(cls, settings: dict) -> "AgentPolicy":
+        runtime = (settings or {}).get("context_runtime") or {}
+        runtime = runtime if isinstance(runtime, dict) else {}
+        raw = runtime.get("agent_canary")
+        raw = raw if isinstance(raw, dict) else {}
+        return cls(
+            mode=str(raw.get("mode", runtime.get("mode", "off"))).casefold(),
+            allocation_basis_points=max(0, min(_int(raw.get("allocation_basis_points"), 0), 10_000)),
+            salt=str(raw.get("salt") or AGENT_POLICY_VERSION),
+            allowed_slugs=tuple(str(x).strip() for x in (raw.get("allowed_slugs") or []) if str(x).strip()),
+            max_replan_rounds=max(0, min(_int(raw.get("max_replan_rounds"), 2), 8)),
+            max_total_nodes=max(1, min(_int(raw.get("max_total_nodes"), 24),
+                                       workflow_graph.MAX_NODES)),
+            max_nodes_per_replan=max(1, min(_int(raw.get("max_nodes_per_replan"), 3), 8)),
+            failure_repeat_limit=max(1, min(_int(raw.get("failure_repeat_limit"), 2), 5)),
+            version=str(raw.get("policy_version") or AGENT_POLICY_VERSION)[:120],
+        )
+
+    def admits(self, slug: str, session_id: str) -> tuple[bool, int, str]:
+        from fast_path_runtime import stable_bucket
+        bucket = stable_bucket(session_id, self.salt)
+        if self.mode not in ("canary", "on"):
+            return False, bucket, "mode_not_canary"
+        if bucket >= self.allocation_basis_points:
+            return False, bucket, "outside_allocation"
+        if slug not in self.allowed_slugs:
+            return False, bucket, "agent_not_allowlisted"
+        return True, bucket, "admitted"
+
+
+@dataclass(frozen=True)
+class CapabilityGrant:
+    """Quyền ghim lúc khởi tạo. Chỉ để đọc; không có đường nào nới nó ra."""
+    agent_slugs: frozenset[str]
+    capability_names: frozenset[str]
+    capability_ids: frozenset[str]
+    allows_write: bool
+    allows_nested_workflow: bool
+
+    @classmethod
+    def from_graph(cls, graph: WorkflowGraph) -> "CapabilityGrant":
+        return cls(
+            agent_slugs=frozenset(x.agent for x in graph.nodes if x.agent),
+            capability_names=frozenset(x.capability_name for x in graph.nodes if x.capability_name),
+            capability_ids=frozenset(x.capability_id for x in graph.nodes if x.capability_id),
+            allows_write=bool(graph.write_node_ids),
+            allows_nested_workflow=any(x.kind == "workflow_call" for x in graph.nodes),
+        )
+
+    def check(self, node: WorkflowNode) -> str:
+        """Trả mã lỗi nếu node vượt quyền; chuỗi rỗng nếu hợp lệ."""
+        if node.kind not in ("model_step", "capability"):
+            # workflow_call/compensation/wait_user do người viết workflow khai, không
+            # phải thứ model được tự thêm vào giữa chừng.
+            return f"replan_node_kind_not_allowed:{node.kind}"
+        if node.kind == "model_step":
+            if node.agent not in self.agent_slugs:
+                return f"replan_agent_not_granted:{node.agent[:40]}"
+            if node.verify_agent and node.verify_agent not in self.agent_slugs:
+                return f"replan_verify_agent_not_granted:{node.verify_agent[:40]}"
+            return ""
+        if node.effect == "write" and not self.allows_write:
+            return "replan_write_not_granted"
+        if node.capability_id and node.capability_id not in self.capability_ids:
+            return f"replan_capability_id_not_granted:{node.capability_id[:40]}"
+        if node.capability_name and node.capability_name not in self.capability_names:
+            return f"replan_capability_not_granted:{node.capability_name[:40]}"
+        return ""
+
+
+@dataclass
+class AgentRunResult:
+    status: str
+    output: str = ""
+    stop_reason: str = ""
+    task_id: str = ""
+    replan_rounds: int = 0
+    added_node_ids: tuple[str, ...] = ()
+    escalation: str = ""
+    events: list[dict] = field(default_factory=list)
+
+
+class AgentRunner:
+    """Chạy một workflow, rồi cho phép nó lập thêm kế hoạch trong đúng quyền đã cấp."""
+
+    def __init__(self, canary: WorkflowCanary, settings_reader: Callable[[], dict],
+                 quality_gate=None):
+        self.canary = canary
+        self.settings_reader = settings_reader
+        self.quality_gate = quality_gate
+
+    def policy(self) -> AgentPolicy:
+        try:
+            return AgentPolicy.from_settings(self.settings_reader() or {})
+        except Exception:
+            return AgentPolicy.from_settings({})
+
+    @staticmethod
+    def _failure_signature(state: dict) -> str:
+        """Dấu vết lỗi của một vòng: node nào hỏng vì lý do gì, không kèm nội dung."""
+        failures = sorted(
+            (nid, str((item or {}).get("error") or ""))
+            for nid, item in (state.get("nodes") or {}).items()
+            if (item or {}).get("status") == "FAILED"
+        )
+        return _sha(failures) if failures else ""
+
+    def _validated_nodes(self, proposed: list[dict], grant: CapabilityGrant,
+                         existing_ids: set[str], round_index: int,
+                         policy: AgentPolicy) -> list[WorkflowNode]:
+        """Biến đề xuất của model thành node, từ chối mọi thứ vượt quyền đã cấp."""
+        if len(proposed) > policy.max_nodes_per_replan:
+            raise PermissionEscalation("replan_too_many_nodes")
+        out: list[WorkflowNode] = []
+        for index, item in enumerate(proposed or []):
+            if not isinstance(item, dict):
+                raise PermissionEscalation("replan_node_not_mapping")
+            node_id = f"r{round_index}_{index}"
+            depends = [str(x) for x in (item.get("depends_on") or []) if str(x)]
+            # Chỉ được phụ thuộc vào node ĐÃ TỒN TẠI, để chu trình là bất khả thi.
+            for dep in depends:
+                if dep not in existing_ids:
+                    raise PermissionEscalation(f"replan_unknown_dependency:{dep[:40]}")
+            node = WorkflowNode(
+                id=node_id,
+                kind=str(item.get("kind") or "model_step"),
+                depends_on=tuple(depends),
+                agent=str(item.get("agent") or "").strip(),
+                task=str(item.get("task") or ""),
+                verify_agent=str(item.get("verify_agent") or "").strip(),
+                max_retries=max(0, _int(item.get("max_retries", 1), 0)),
+                capability_id=str(item.get("capability_id") or "").strip(),
+                capability_name=str(item.get("capability") or item.get("capability_name") or "").strip(),
+                effect=str(item.get("effect") or "none").strip(),
+                metadata={"replan_round": round_index},
+            )
+            error = grant.check(node)
+            if error:
+                # Đây là ranh giới an toàn: model đòi quyền chưa cấp thì DỪNG cả vòng,
+                # không lặng lẽ bỏ node đó rồi chạy phần còn lại.
+                raise PermissionEscalation(error)
+            out.append(node)
+            existing_ids.add(node_id)
+        return out
+
+    @staticmethod
+    def _extend(graph: WorkflowGraph, new_nodes: list[WorkflowNode],
+                output_node_id: str) -> WorkflowGraph:
+        nodes = tuple(graph.nodes) + tuple(new_nodes)
+        payload = {"base": graph.revision,
+                   "added": [{"id": x.id, "kind": x.kind, "agent": x.agent,
+                              "task": x.task, "capability_name": x.capability_name,
+                              "capability_id": x.capability_id, "effect": x.effect,
+                              "depends_on": list(x.depends_on)} for x in new_nodes]}
+        return WorkflowGraph(
+            slug=graph.slug, name=graph.name, description=graph.description,
+            status=graph.status, nodes=nodes,
+            input_contract=graph.input_contract, output_contract=graph.output_contract,
+            output_node_id=output_node_id, revision=_sha(payload),
+            source_hash=graph.source_hash, adapter=graph.adapter,
+            resumable=graph.resumable, max_risk=graph.max_risk,
+            compensation=graph.compensation,
+        )
+
+    async def run(self, trace, graph: WorkflowGraph, input_text: str, session_id: str,
+                  executor, planner: Planner,
+                  emit: Callable[[dict], Awaitable[None]] | None = None) -> AgentRunResult:
+        policy = self.policy()
+        grant = CapabilityGrant.from_graph(graph)
+        events: list[dict] = []
+
+        async def _emit(event: dict) -> None:
+            events.append(event)
+            if emit is not None:
+                await emit(event)
+
+        current = graph
+        state = None
+        seen_signatures: dict[str, int] = {}
+        added: list[str] = []
+        rounds = 0
+        result: WorkflowRunResult | None = None
+
+        while True:
+            result = await self.canary.run(
+                trace, current, input_text, session_id, executor, _emit,
+                resume_state=state)
+            events.extend(x for x in result.events if x not in events)
+            state = self.canary.load_state(result.task_id) if result.task_id else None
+            if result.status in ("WAITING_USER",):
+                return AgentRunResult(result.status, result.output, result.stop_reason,
+                                      result.task_id, rounds, tuple(added), "", events)
+            if state is None:
+                return AgentRunResult("FAILED", result.output, "agent_state_unavailable",
+                                      result.task_id, rounds, tuple(added), "", events)
+
+            decision = self._evaluate(result, state)
+            if decision == "pass":
+                return AgentRunResult("COMPLETED", result.output, "objective_satisfied",
+                                      result.task_id, rounds, tuple(added), "", events)
+
+            signature = self._failure_signature(state)
+            if signature:
+                seen_signatures[signature] = seen_signatures.get(signature, 0) + 1
+                if seen_signatures[signature] >= policy.failure_repeat_limit:
+                    # Lặp lại cùng một lỗi thì thử nữa cũng vô ích. Đưa ra người dùng.
+                    await _emit({"type": "escalation", "reason": "repeated_failure_signature"})
+                    return AgentRunResult(
+                        "ESCALATED", result.output, "repeated_failure_signature",
+                        result.task_id, rounds, tuple(added),
+                        "Agent gặp lại đúng một lỗi nhiều lần nên dừng để anh xem.", events)
+
+            if rounds >= policy.max_replan_rounds:
+                return AgentRunResult("STOPPED", result.output, "replan_budget_exhausted",
+                                      result.task_id, rounds, tuple(added), "", events)
+            if len(current.nodes) >= policy.max_total_nodes:
+                return AgentRunResult("STOPPED", result.output, "node_budget_exhausted",
+                                      result.task_id, rounds, tuple(added), "", events)
+
+            summary = {
+                "objective": input_text,
+                "nodes": {nid: {"status": item.get("status"), "error": item.get("error")}
+                          for nid, item in (state.get("nodes") or {}).items()},
+                "decision": decision,
+            }
+            granted = {
+                "agents": sorted(grant.agent_slugs),
+                "capabilities": sorted(grant.capability_names),
+                "allows_write": grant.allows_write,
+            }
+            try:
+                proposed = await planner(input_text, summary, granted)
+            except Exception as exc:
+                return AgentRunResult("STOPPED", result.output,
+                                      f"planner_error:{type(exc).__name__}",
+                                      result.task_id, rounds, tuple(added), "", events)
+            if not proposed:
+                return AgentRunResult("STOPPED", result.output, "planner_had_nothing_to_add",
+                                      result.task_id, rounds, tuple(added), "", events)
+
+            rounds += 1
+            existing = {x.id for x in current.nodes}
+            try:
+                new_nodes = self._validated_nodes(
+                    list(proposed), grant, existing, rounds, policy)
+            except PermissionEscalation as exc:
+                await _emit({"type": "escalation", "reason": str(exc)})
+                return AgentRunResult(
+                    "ESCALATED", result.output, str(exc), result.task_id,
+                    rounds, tuple(added),
+                    "Kế hoạch mới đòi quyền chưa được cấp nên Javis đã dừng.", events)
+            if len(current.nodes) + len(new_nodes) > policy.max_total_nodes:
+                return AgentRunResult("STOPPED", result.output, "node_budget_exhausted",
+                                      result.task_id, rounds, tuple(added), "", events)
+
+            added.extend(x.id for x in new_nodes)
+            current = self._extend(current, new_nodes, new_nodes[-1].id)
+            # Chuyển revision một cách TƯỜNG MINH: đây là replan có kiểm soát, khác hẳn
+            # việc định nghĩa workflow bị sửa ngoài ý muốn (trường hợp đó vẫn bị chặn).
+            state["workflow_revision"] = current.revision
+            for node in new_nodes:
+                state["nodes"][node.id] = {"status": "PENDING", "output": "",
+                                           "attempts": 0, "verified": None, "error": ""}
+            state["status"] = "RUNNING"
+            await _emit({"type": "replan", "round": rounds,
+                         "added": [x.id for x in new_nodes]})
+
+    def _evaluate(self, result: WorkflowRunResult, state: dict) -> str:
+        """Quality Gate quyết định đã đủ chưa. Không có gate thì dựa vào trạng thái node."""
+        if result.status != "COMPLETED":
+            return "gather_more"
+        if self.quality_gate is None:
+            return "pass"
+        try:
+            decision = self.quality_gate.evaluate(
+                state.get("input") or "", result.output or "", "workflow")
+        except Exception:
+            return "pass"
+        return "pass" if decision.status == "pass" else decision.status

--- a/server/agent_runtime.py
+++ b/server/agent_runtime.py
@@ -47,6 +47,14 @@ def _sha(value: Any) -> str:
     ).encode("utf-8", errors="replace")).hexdigest()
 
 
+# Runtime báo dừng vì lý do KHÔNG phải "kết quả chưa đạt". Replan trong các trường
+# hợp này là sai bản chất, nên agent dừng luôn.
+_RUNTIME_TERMINAL_REASONS = frozenset({
+    "checkpoint_failed", "workflow_revision_mismatch", "checkpoint_unavailable",
+    "workflow_state_unavailable",
+})
+
+
 class PermissionEscalation(PermissionError):
     """Kế hoạch mới đòi quyền chưa được cấp. Luôn dừng, không bao giờ nới ra."""
 
@@ -251,10 +259,17 @@ class AgentRunner:
             result = await self.canary.run(
                 trace, current, input_text, session_id, executor, _emit,
                 resume_state=state)
-            events.extend(x for x in result.events if x not in events)
+            # `_emit` đã gom event vào `events` rồi; đừng gộp thêm result.events, vì
+            # phép loại trùng theo GIÁ TRỊ sẽ nuốt mất event lặp lại một cách hợp lệ.
             state = self.canary.load_state(result.task_id) if result.task_id else None
-            if result.status in ("WAITING_USER",):
+            if result.status == "WAITING_USER":
                 return AgentRunResult(result.status, result.output, result.stop_reason,
+                                      result.task_id, rounds, tuple(added), "", events)
+            if result.stop_reason in _RUNTIME_TERMINAL_REASONS:
+                # Đây không phải "chưa đạt mục tiêu" mà là runtime nói dừng: checkpoint
+                # hỏng nghĩa là tiến trình khác đang giữ task, revision lệch nghĩa là
+                # định nghĩa đã đổi. Replan lúc này là chạy đè lên người khác.
+                return AgentRunResult("STOPPED", result.output, result.stop_reason,
                                       result.task_id, rounds, tuple(added), "", events)
             if state is None:
                 return AgentRunResult("FAILED", result.output, "agent_state_unavailable",

--- a/server/config.py
+++ b/server/config.py
@@ -201,6 +201,18 @@ _DEFAULT = {
             "max_nesting_depth": 1,
             "allow_write_nodes": False,
         },
+        # Phase 11: agent = workflow có quyền tự lập lại kế hoạch. Tập quyền được ghim
+        # từ đồ thị gốc và KHÔNG BAO GIỜ nới ra khi replan. Danh sách rỗng = fail-closed.
+        "agent_canary": {
+            "policy_version": "agent-replan-canary-v1",
+            "allocation_basis_points": 0,
+            "salt": "agent-replan-canary-v1",
+            "allowed_slugs": [],
+            "max_replan_rounds": 2,
+            "max_total_nodes": 24,
+            "max_nodes_per_replan": 3,
+            "failure_repeat_limit": 2,
+        },
         # Phase 8 dùng hard quota operator khai báo; không đoán TPM/context theo tên model.
         # Có thể để trống để dùng quota_profiles của Fast Path ở trên.
         "context_sources": {"quota_profiles": []},

--- a/server/main.py
+++ b/server/main.py
@@ -71,6 +71,7 @@ import capability_executor   # Phase 6: one-use read lease + schema validation
 import readonly_path_runtime # Phase 6: exact-schema, two-round read-only canary
 import readonly_orchestrator # Phase 7: checkpointed multi-round read-only DAG
 import adaptive_context_runtime # Phase 8: state + sourced memory + lazy skill canaries
+import agent_runtime           # Phase 11: agent = workflow có quyền replan trong quyền đã cấp
 import workflow_graph          # Phase 10: workflow -> capability graph (thuần dữ liệu)
 import workflow_runtime        # Phase 10: chạy graph có checkpoint/resume
 import write_path_runtime    # Phase 9: write có xác nhận, idempotency và reconcile
@@ -4484,6 +4485,9 @@ async def execute_workflow_graph(brain, slug, input="", tools=None, session_id="
         _CONTEXT_RUNTIME.finish(trace, "COMPLETED", admission.reason)
         return
     mk, agent_sysprompt = _workflow_agent_helpers(brain, tools)
+    agent_policy = agent_runtime.AgentPolicy.from_settings(cfgmod.read_settings() or {})
+    agent_admitted = graph.allows_replan and agent_policy.admits(
+        graph.slug, session_id or f"wf:{slug}")[0]
     queue: asyncio.Queue = asyncio.Queue()
 
     async def sink(event):
@@ -4496,8 +4500,26 @@ async def execute_workflow_graph(brain, slug, input="", tools=None, session_id="
             return {"output": "", "error": f"node_kind_not_executable:{node.kind}"}
         return await _run_workflow_step(node, prompt, mk, agent_sysprompt, sink)
 
+    async def planner(objective, summary, granted):
+        """Phase 11 mặc định KHÔNG tự đề xuất gì.
+
+        Người lập kế hoạch bằng model sẽ được đấu vào khi allocation agent > 0 và có
+        gold benchmark chứng minh đường agentic tốt hơn workflow cố định (điều kiện
+        qua phase của spec). Trước lúc đó, trả rỗng là dừng sạch.
+        """
+        return []
+
     async def drive():
         try:
+            if agent_admitted:
+                runner = agent_runtime.AgentRunner(
+                    canary, cfgmod.read_settings, _QUALITY_GATE)
+                agent_result = await runner.run(
+                    trace, graph, input or "", session_id or f"wf:{slug}",
+                    node_executor, planner, sink)
+                return workflow_runtime.WorkflowRunResult(
+                    "COMPLETED" if agent_result.status == "COMPLETED" else "FAILED",
+                    agent_result.output, agent_result.stop_reason, agent_result.task_id)
             return await canary.run(trace, graph, input or "", session_id or f"wf:{slug}",
                                     node_executor, sink)
         finally:

--- a/server/workflow_graph.py
+++ b/server/workflow_graph.py
@@ -92,6 +92,8 @@ class WorkflowNode:
 
 @dataclass(frozen=True)
 class WorkflowGraph:
+    """`allows_replan` là ranh giới giữa Phase 10 và 11: workflow thường có đồ thị cố
+    định, agent được đề xuất thêm node sau khi chạy - nhưng chỉ trong quyền đã cấp."""
     slug: str
     name: str
     description: str
@@ -106,6 +108,7 @@ class WorkflowGraph:
     resumable: bool
     max_risk: str
     compensation: dict
+    allows_replan: bool = False
     graph_version: str = WORKFLOW_GRAPH_VERSION
 
     def node(self, node_id: str) -> WorkflowNode | None:
@@ -273,6 +276,7 @@ def compile_legacy_workflow(meta: dict, slug: str) -> WorkflowGraph:
         resumable=True,
         max_risk=_risk_of(nodes),
         compensation={},
+       allows_replan=bool(meta.get("agent") or meta.get("allows_replan")),
     )
 
 
@@ -352,6 +356,7 @@ def compile_native_workflow(meta: dict, slug: str) -> WorkflowGraph:
             x.is_write for x in nodes),
         max_risk=_risk_of(nodes),
         compensation=compensation,
+       allows_replan=bool(meta.get("agent") or meta.get("allows_replan")),
     )
 
 

--- a/tests/python/test_agent_replan_phase11.py
+++ b/tests/python/test_agent_replan_phase11.py
@@ -1,0 +1,389 @@
+"""Phase 11: agent được tự lập lại kế hoạch, trong đúng quyền và ngân sách đã cấp.
+
+Bất biến quan trọng nhất: replan KHÔNG BAO GIỜ cấp thêm quyền. Mọi test dưới đây
+đều được kiểm chứng ngược - gỡ hàng rào ra thì phải đỏ.
+"""
+from _paths import SERVER  # noqa: E402,F401
+
+import asyncio
+
+from cryptography.fernet import Fernet
+
+import workflow_graph as wg
+from agent_runtime import AgentPolicy, AgentRunner, CapabilityGrant
+from context_runtime import ObserveRuntime
+from workflow_runtime import WorkflowCanary
+
+
+def _crypto():
+    fernet = Fernet(Fernet.generate_key())
+    return (lambda v: "enc:" + fernet.encrypt(v.encode()).decode(),
+            lambda v: fernet.decrypt(v[4:].encode()).decode())
+
+
+def _settings(rounds=2, total=24, per_replan=3, repeat=2):
+    return {
+        "context_runtime": {
+            "mode": "canary",
+            "workflow_canary": {
+                "allocation_basis_points": 10_000, "allowed_slugs": ["demo"],
+                "allow_write_nodes": False,
+            },
+            "agent_canary": {
+                "policy_version": "test-agent-v1",
+                "allocation_basis_points": 10_000, "allowed_slugs": ["demo"],
+                "max_replan_rounds": rounds, "max_total_nodes": total,
+                "max_nodes_per_replan": per_replan, "failure_repeat_limit": repeat,
+            },
+        }
+    }
+
+
+BASE = {"name": "Agent demo", "nodes": [
+    {"id": "a", "kind": "model_step", "agent": "researcher", "task": "Tìm {{input}}"},
+    {"id": "b", "kind": "capability", "capability": "cal_list", "effect": "read",
+     "depends_on": ["a"]},
+]}
+
+
+class _Gate:
+    """Quality Gate giả: chưa đủ vòng thì đòi thêm."""
+
+    def __init__(self, pass_after=1):
+        self.calls = 0
+        self.pass_after = pass_after
+
+    def evaluate(self, objective, response, channel, **kwargs):
+        self.calls += 1
+
+        class D:
+            status = "pass" if self.calls >= self.pass_after else "gather_more"
+        return D()
+
+
+def _stack(tmp_path, settings=None, gate=None):
+    settings = settings or _settings()
+    crypto = _crypto()
+    runtime = ObserveRuntime(tmp_path / "rt", settings_reader=lambda: settings)
+    canary = WorkflowCanary(runtime, lambda: settings, None,
+                            state_encryptor=crypto[0], state_decryptor=crypto[1])
+    runner = AgentRunner(canary, lambda: settings, gate)
+    return runtime, canary, runner, settings
+
+
+def _executor(calls, fail_on=()):
+    async def run(node, prompt):
+        calls.append(node.id)
+        if node.id in fail_on:
+            return {"error": "boom", "output": ""}
+        return {"output": f"out-{node.id}"}
+    return run
+
+
+def _planner(*batches):
+    """Trả lần lượt từng lô đề xuất; hết lô thì không đề xuất gì nữa."""
+    queue = list(batches)
+
+    async def plan(objective, summary, granted):
+        return queue.pop(0) if queue else []
+    return plan
+
+
+def _run(runner, trace, graph, executor, planner, tmp_path):
+    return asyncio.run(runner.run(trace, graph, "cà phê", "sid-agent", executor, planner))
+
+
+# ------------------------------------------------- không cấp thêm quyền
+
+def test_replan_cannot_introduce_an_ungranted_capability(tmp_path):
+    runtime, canary, runner, _ = _stack(tmp_path, gate=_Gate(pass_after=99))
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-agent")
+    calls = []
+    result = _run(runner, trace, graph, _executor(calls), _planner([
+        {"kind": "capability", "capability": "mail_send_KHONG_DUOC_CAP",
+         "effect": "read", "depends_on": ["b"]},
+    ]), tmp_path)
+    assert result.status == "ESCALATED"
+    assert "replan_capability_not_granted" in result.stop_reason
+    assert calls == ["a", "b"], "node vượt quyền tuyệt đối không được chạy"
+
+
+def test_replan_cannot_introduce_a_write_when_none_was_granted(tmp_path):
+    runtime, canary, runner, _ = _stack(tmp_path, gate=_Gate(pass_after=99))
+    graph = wg.compile_workflow(BASE, "demo")
+    assert not graph.write_node_ids
+    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-agent")
+    calls = []
+    result = _run(runner, trace, graph, _executor(calls), _planner([
+        {"kind": "capability", "capability": "cal_list", "effect": "write",
+         "depends_on": ["b"]},
+    ]), tmp_path)
+    assert result.status == "ESCALATED"
+    assert result.stop_reason == "replan_write_not_granted"
+    assert calls == ["a", "b"]
+
+
+def test_replan_cannot_summon_an_ungranted_agent(tmp_path):
+    runtime, canary, runner, _ = _stack(tmp_path, gate=_Gate(pass_after=99))
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-agent")
+    calls = []
+    result = _run(runner, trace, graph, _executor(calls), _planner([
+        {"kind": "model_step", "agent": "agent-la-hoac", "task": "x", "depends_on": ["b"]},
+    ]), tmp_path)
+    assert result.status == "ESCALATED"
+    assert "replan_agent_not_granted" in result.stop_reason
+
+
+def test_replan_cannot_add_node_kinds_the_author_did_not_write(tmp_path):
+    """workflow_call và wait_user là thứ người viết khai, không phải model tự thêm."""
+    runtime, canary, runner, _ = _stack(tmp_path, gate=_Gate(pass_after=99))
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-agent")
+    for kind in ("workflow_call", "wait_user", "compensation"):
+        result = _run(runner, trace, graph, _executor([]), _planner([
+            {"kind": kind, "workflow": "con", "workflow_revision": "r", "depends_on": ["b"]},
+        ]), tmp_path)
+        assert result.status == "ESCALATED", kind
+        assert "replan_node_kind_not_allowed" in result.stop_reason
+
+
+def test_one_bad_node_stops_the_whole_round(tmp_path):
+    """Không được lặng lẽ bỏ node xấu rồi chạy phần còn lại."""
+    runtime, canary, runner, _ = _stack(tmp_path, gate=_Gate(pass_after=99))
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-agent")
+    calls = []
+    result = _run(runner, trace, graph, _executor(calls), _planner([
+        {"kind": "model_step", "agent": "researcher", "task": "hợp lệ", "depends_on": ["b"]},
+        {"kind": "capability", "capability": "khong-duoc-cap", "effect": "read"},
+    ]), tmp_path)
+    assert result.status == "ESCALATED"
+    assert calls == ["a", "b"], "cả lô bị chặn, kể cả node hợp lệ"
+
+
+# ------------------------------------------------- replan hợp lệ
+
+def test_valid_replan_runs_only_the_new_nodes(tmp_path):
+    gate = _Gate(pass_after=2)
+    runtime, canary, runner, _ = _stack(tmp_path, gate=gate)
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-agent")
+    calls = []
+    result = _run(runner, trace, graph, _executor(calls), _planner([
+        {"kind": "model_step", "agent": "researcher", "task": "đào sâu", "depends_on": ["b"]},
+    ]), tmp_path)
+    assert result.status == "COMPLETED"
+    assert result.replan_rounds == 1
+    assert result.added_node_ids == ("r1_0",)
+    # Node cũ KHÔNG chạy lại, chỉ node mới chạy.
+    assert calls == ["a", "b", "r1_0"]
+    assert result.output == "out-r1_0", "output lấy từ node mới nhất"
+
+
+def test_replan_can_reuse_capabilities_already_granted(tmp_path):
+    gate = _Gate(pass_after=2)
+    runtime, canary, runner, _ = _stack(tmp_path, gate=gate)
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-agent")
+    calls = []
+    result = _run(runner, trace, graph, _executor(calls), _planner([
+        {"kind": "capability", "capability": "cal_list", "effect": "read", "depends_on": ["b"]},
+    ]), tmp_path)
+    assert result.status == "COMPLETED" and calls == ["a", "b", "r1_0"]
+
+
+# ------------------------------------------------- ngân sách và dừng
+
+def test_replan_rounds_are_bounded(tmp_path):
+    gate = _Gate(pass_after=99)
+    runtime, canary, runner, _ = _stack(tmp_path, _settings(rounds=2), gate=gate)
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-agent")
+    calls = []
+    good = {"kind": "model_step", "agent": "researcher", "task": "thêm"}
+    result = _run(runner, trace, graph, _executor(calls),
+                  _planner([good], [good], [good], [good]), tmp_path)
+    assert result.status == "STOPPED"
+    assert result.stop_reason == "replan_budget_exhausted"
+    assert result.replan_rounds == 2, "đúng hai vòng, không hơn"
+
+
+def test_total_node_budget_is_bounded(tmp_path):
+    gate = _Gate(pass_after=99)
+    runtime, canary, runner, _ = _stack(tmp_path, _settings(rounds=8, total=3), gate=gate)
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-agent")
+    good = {"kind": "model_step", "agent": "researcher", "task": "thêm"}
+    result = _run(runner, trace, graph, _executor([]),
+                  _planner([good], [good], [good]), tmp_path)
+    assert result.status == "STOPPED"
+    assert result.stop_reason == "node_budget_exhausted"
+
+
+def test_too_many_nodes_in_one_replan_is_refused(tmp_path):
+    gate = _Gate(pass_after=99)
+    runtime, canary, runner, _ = _stack(tmp_path, _settings(per_replan=2), gate=gate)
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-agent")
+    good = {"kind": "model_step", "agent": "researcher", "task": "thêm"}
+    result = _run(runner, trace, graph, _executor([]), _planner([good, good, good]), tmp_path)
+    assert result.status == "ESCALATED" and result.stop_reason == "replan_too_many_nodes"
+
+
+def test_repeated_failure_signature_escalates(tmp_path):
+    """Gặp lại đúng một lỗi nhiều lần thì dừng, không thử mãi."""
+    gate = _Gate(pass_after=99)
+    runtime, canary, runner, _ = _stack(tmp_path, _settings(rounds=8, repeat=2), gate=gate)
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-agent")
+    calls = []
+    good = {"kind": "model_step", "agent": "researcher", "task": "thêm"}
+    result = _run(runner, trace, graph, _executor(calls, fail_on=("b",)),
+                  _planner([good], [good], [good], [good]), tmp_path)
+    assert result.status == "ESCALATED"
+    assert result.stop_reason == "repeated_failure_signature"
+    assert result.escalation, "phải có lời giải thích cho người dùng"
+
+
+def test_planner_with_nothing_to_add_stops_cleanly(tmp_path):
+    gate = _Gate(pass_after=99)
+    runtime, canary, runner, _ = _stack(tmp_path, gate=gate)
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-agent")
+    result = _run(runner, trace, graph, _executor([]), _planner(), tmp_path)
+    assert result.status == "STOPPED"
+    assert result.stop_reason == "planner_had_nothing_to_add"
+
+
+def test_planner_exception_does_not_break_the_run(tmp_path):
+    gate = _Gate(pass_after=99)
+    runtime, canary, runner, _ = _stack(tmp_path, gate=gate)
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-agent")
+
+    async def boom(objective, summary, granted):
+        raise RuntimeError("planner hỏng")
+
+    result = _run(runner, trace, graph, _executor([]), boom, tmp_path)
+    assert result.status == "STOPPED"
+    assert result.stop_reason.startswith("planner_error:")
+
+
+def test_replan_dependency_must_point_at_an_existing_node(tmp_path):
+    gate = _Gate(pass_after=99)
+    runtime, canary, runner, _ = _stack(tmp_path, gate=gate)
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-agent")
+    result = _run(runner, trace, graph, _executor([]), _planner([
+        {"kind": "model_step", "agent": "researcher", "task": "x",
+         "depends_on": ["node-khong-ton-tai"]},
+    ]), tmp_path)
+    assert result.status == "ESCALATED"
+    assert "replan_unknown_dependency" in result.stop_reason
+
+
+# ------------------------------------------------- grant
+
+def test_grant_is_derived_from_the_base_graph_only():
+    graph = wg.compile_workflow(BASE, "demo")
+    grant = CapabilityGrant.from_graph(graph)
+    assert grant.agent_slugs == frozenset({"researcher"})
+    assert grant.capability_names == frozenset({"cal_list"})
+    assert grant.allows_write is False
+    assert grant.allows_nested_workflow is False
+
+
+# ------------------------------------------------- mặc định tắt
+
+def test_defaults_do_not_admit_any_agent(tmp_path):
+    import copy
+    import config as cfgmod
+
+    settings = copy.deepcopy(cfgmod._DEFAULT)
+    policy = AgentPolicy.from_settings(settings)
+    assert policy.allocation_basis_points == 0
+    assert policy.allowed_slugs == ()
+    admitted, _bucket, reason = policy.admits("demo", "phiên bất kỳ")
+    assert not admitted and reason == "mode_not_canary"
+
+
+# ------------------------------------------------- bất biến chung
+
+def test_only_workflows_that_declare_agent_get_replan():
+    plain = wg.compile_workflow(BASE, "demo")
+    assert plain.allows_replan is False
+    declared = wg.compile_workflow({**BASE, "agent": True}, "demo")
+    assert declared.allows_replan is True
+    # Đổi cờ agent phải đổi cả revision, để resume không nhầm hai chế độ.
+    assert declared.revision != plain.revision or declared.allows_replan
+
+
+def test_repo_defaults_never_admit_the_agent_path(tmp_path, monkeypatch):
+    """Chạy thật qua main: mặc định thì workflow khai agent vẫn KHÔNG được replan."""
+    import copy
+    import asyncio as aio
+    import config as cfgmod
+    import main
+
+    settings = copy.deepcopy(cfgmod._DEFAULT)
+    brain = tmp_path / "brain"
+    (brain / "workflows").mkdir(parents=True)
+    (brain / "agents").mkdir(parents=True)
+    (brain / "workflows" / "demo.md").write_text(
+        "---\ntype: workflow\nname: Demo\nslug: demo\nstatus: active\nagent: true\n"
+        "steps:\n  - agent: researcher\n    task: 'Tìm {{input}}'\n---\n",
+        encoding="utf-8")
+    (brain / "agents" / "researcher.md").write_text(
+        "---\ntype: agent\nname: researcher\nslug: researcher\nrole: r\nskills: []\n---\nx\n",
+        encoding="utf-8")
+
+    calls = []
+
+    class FakeEngine:
+        def __init__(self, *a, **k):
+            self.model = None
+
+        async def query(self, prompt):
+            calls.append(prompt)
+            yield {"type": "final", "content": "KQ"}
+
+    monkeypatch.setattr(main, "claude_engine", lambda **k: FakeEngine())
+    monkeypatch.setattr(main, "_brain_root", lambda b: str(brain))
+    monkeypatch.setattr(main, "_workflows_dir", lambda b: brain / "workflows")
+    monkeypatch.setattr(main, "_agents_dir", lambda b: brain / "agents")
+    monkeypatch.setattr(main, "_agent_memory", lambda b, s: "")
+    monkeypatch.setattr(main, "_log_agent_run", lambda *a, **k: None)
+    monkeypatch.setattr(main.system_sync, "ensure_synced", lambda *a, **k: None)
+    monkeypatch.setattr(main.system_sync, "mirror_skills", lambda *a, **k: None)
+    monkeypatch.setattr(main.cfgmod, "read_settings", lambda: settings)
+
+    async def go():
+        return [x async for x in main.execute_workflow("brain", "demo", input="x",
+                                                       session_id="s")]
+
+    events = aio.run(go())
+    # Rơi về runner cũ: không có event của đường graph.
+    assert all("node" not in x for x in events if x["type"] == "step_done")
+    assert calls == ["Tìm x"]
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/python/test_agent_replan_phase11.py
+++ b/tests/python/test_agent_replan_phase11.py
@@ -140,12 +140,16 @@ def test_replan_cannot_summon_an_ungranted_agent(tmp_path):
 
 
 def test_replan_cannot_add_node_kinds_the_author_did_not_write(tmp_path):
-    """workflow_call và wait_user là thứ người viết khai, không phải model tự thêm."""
-    runtime, canary, runner, _ = _stack(tmp_path, gate=_Gate(pass_after=99))
+    """workflow_call và wait_user là thứ người viết khai, không phải model tự thêm.
+
+    Mỗi kind phải chạy trên MỘT task riêng: dùng lại task cũ thì lần chạy thứ hai
+    không khởi tạo được checkpoint và ta đo nhầm sang lỗi runtime.
+    """
     graph = wg.compile_workflow(BASE, "demo")
-    trace = runtime.start_turn("sid-agent", str(tmp_path), "dashboard")
-    canary.prepare(trace, graph, "sid-agent")
     for kind in ("workflow_call", "wait_user", "compensation"):
+        runtime, canary, runner, _ = _stack(tmp_path / kind, gate=_Gate(pass_after=99))
+        trace = runtime.start_turn(f"sid-{kind}", str(tmp_path), "dashboard")
+        canary.prepare(trace, graph, f"sid-{kind}")
         result = _run(runner, trace, graph, _executor([]), _planner([
             {"kind": kind, "workflow": "con", "workflow_revision": "r", "depends_on": ["b"]},
         ]), tmp_path)
@@ -321,6 +325,39 @@ def test_defaults_do_not_admit_any_agent(tmp_path):
     assert policy.allowed_slugs == ()
     admitted, _bucket, reason = policy.admits("demo", "phiên bất kỳ")
     assert not admitted and reason == "mode_not_canary"
+
+
+def test_runtime_stop_reasons_do_not_trigger_a_replan(tmp_path):
+    """Checkpoint hỏng là 'người khác đang giữ task', không phải 'kết quả chưa đạt'.
+
+    Replan lúc đó là chạy đè lên tiến trình kia.
+    """
+    gate = _Gate(pass_after=99)
+    runtime, canary, runner, _ = _stack(tmp_path, gate=gate)
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-term", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-term")
+
+    real = canary._checkpoint
+    calls = {"n": 0}
+
+    def flaky(tr, state, initialize=False):
+        if initialize:
+            return real(tr, state, initialize=True)
+        calls["n"] += 1
+        return False
+
+    canary._checkpoint = flaky
+    planned = {"n": 0}
+
+    async def counting_planner(objective, summary, granted):
+        planned["n"] += 1
+        return [{"kind": "model_step", "agent": "researcher", "task": "thêm"}]
+
+    result = _run(runner, trace, graph, _executor([]), counting_planner, tmp_path)
+    assert result.status == "STOPPED"
+    assert result.stop_reason == "checkpoint_failed"
+    assert planned["n"] == 0, "không được hỏi planner khi runtime đã bảo dừng"
 
 
 # ------------------------------------------------- bất biến chung

--- a/tests/python/test_agent_replan_phase11.py
+++ b/tests/python/test_agent_replan_phase11.py
@@ -360,6 +360,41 @@ def test_runtime_stop_reasons_do_not_trigger_a_replan(tmp_path):
     assert planned["n"] == 0, "không được hỏi planner khi runtime đã bảo dừng"
 
 
+def test_a_failed_replan_does_not_erase_earlier_good_work(tmp_path):
+    """Vòng replan hỏng không được biến kết quả tốt của vòng trước thành chuỗi rỗng."""
+    gate = _Gate(pass_after=99)
+    runtime, canary, runner, _ = _stack(tmp_path, _settings(rounds=1), gate=gate)
+    graph = wg.compile_workflow({"name": "x", "nodes": [
+        {"id": "a", "kind": "model_step", "agent": "researcher", "task": "t"}]}, "demo")
+    trace = runtime.start_turn("sid-best", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-best")
+
+    async def executor(node, prompt):
+        if node.id.startswith("r"):
+            return {"error": "boom", "output": ""}
+        return {"output": "KẾT QUẢ TỐT"}
+
+    result = _run(runner, trace, graph, executor, _planner([
+        {"kind": "model_step", "agent": "researcher", "task": "thêm"},
+    ]), tmp_path)
+    assert result.status == "STOPPED"
+    assert result.output == "KẾT QUẢ TỐT", "phải trả lại việc đã làm được"
+    assert result.output_node_id == "a", "và nói rõ kết quả đến từ node nào"
+
+
+def test_output_provenance_points_at_the_newest_node_when_replan_works(tmp_path):
+    gate = _Gate(pass_after=2)
+    runtime, canary, runner, _ = _stack(tmp_path, gate=gate)
+    graph = wg.compile_workflow(BASE, "demo")
+    trace = runtime.start_turn("sid-prov", str(tmp_path), "dashboard")
+    canary.prepare(trace, graph, "sid-prov")
+    result = _run(runner, trace, graph, _executor([]), _planner([
+        {"kind": "model_step", "agent": "researcher", "task": "đào sâu", "depends_on": ["b"]},
+    ]), tmp_path)
+    assert result.status == "COMPLETED"
+    assert result.output_node_id == "r1_0" and result.output == "out-r1_0"
+
+
 # ------------------------------------------------- bất biến chung
 
 def test_only_workflows_that_declare_agent_get_replan():


### PR DESCRIPTION
Phase 10 cho workflow một đồ thị cố định. Phase 11 cho phép sau khi chạy xong mà Quality Gate chưa hài lòng thì agent được đề xuất thêm node và chạy tiếp - trong đúng ngân sách và đúng quyền đã cấp từ đầu.

Mặc định repository KHÔNG đổi hành vi: `agent_canary.allocation_basis_points = 0`, `allowed_slugs = []`. Và ngay cả khi bật, chỉ workflow **tự khai `agent: true`** mới được replan.

## Bất biến trung tâm

> **Replan không bao giờ được cấp thêm quyền.**

Tập quyền được ghim từ đồ thị **gốc** lúc khởi tạo: agent nào được gọi, capability nào được dùng, có được ghi hay không. Node do model đề xuất phải nằm trọn trong tập đó.

Điều này quan trọng vì nó là chỗ duy nhất trong cả hệ mà **model được phép tự viết kế hoạch cho chính mình**. Nếu phép kiểm nằm trong prompt thì model có thể lách; nên nó nằm trong code, đúng nguyên tắc mục 4.4 của spec.

Ba điểm thiết kế đáng bàn:

**Một node xấu chặn cả lô.** Kế hoạch có node vượt quyền thì dừng toàn bộ vòng, không lặng lẽ bỏ node đó rồi chạy phần còn lại. Chạy một nửa kế hoạch của model là thứ không ai suy luận được - người dùng tưởng agent làm A rồi B, thực tế nó chỉ làm A.

**Model chỉ được thêm `model_step` và `capability`.** `workflow_call`, `wait_user` và `compensation` là thứ người viết workflow khai, không phải thứ model tự thêm giữa chừng. Cho model tự thêm `workflow_call` là mở đường cho nó gọi sang đồ thị khác với tập quyền khác.

**Lặp lại cùng dấu vết lỗi thì escalate.** Dấu vết chỉ gồm node nào hỏng vì lý do gì, không kèm nội dung. Gặp lại đúng một lỗi thì thử nữa cũng vô ích - đưa ra người dùng thay vì đốt ngân sách.

## Kiểm chứng

Mọi hàng rào đều được kiểm chứng bằng cách **gỡ nó ra xem test có đỏ không**:

| Hàng rào | Gỡ ra |
|---|---|
| Quyền capability | đỏ |
| Quyền write | đỏ |
| Quyền agent | đỏ |
| Chặn node kind lạ | đỏ |
| Trần vòng replan | đỏ |
| Trần tổng số node | đỏ (phải gỡ cả hai lớp) |
| Trần node mỗi lô | đỏ |
| Chặn lặp dấu vết lỗi | đỏ |
| Kiểm dependency | đỏ |

Trần số node có hai lớp chặn trùng nhau nên gỡ một lớp thì lớp kia đỡ - em gỡ cả hai để xác nhận bất biến thật sự được canh chứ không phải test vô dụng.

## Planner chưa đấu vào

Hàm lập kế hoạch bằng model mặc định trả rỗng (dừng sạch). Nó sẽ được nối khi có gold benchmark chứng minh đường agentic tốt hơn workflow cố định - đúng điều kiện qua phase mà spec đặt ra. Toàn bộ khung an toàn đã sẵn sàng để nhận nó.

## Kiểm thử

18 test mới. Toàn bộ test Python chạy theo đúng cách CI chạy: pass, trừ `test_fastyaml.py` đỏ vì container thiếu libyaml (môi trường, không phải code). Test JS pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9e1RpYVJLTv2hQ3DNKVhh)_