### PR TITLE
Adaptive Runtime v2 Phase 12: chọn model theo từng bước (phase cuối)

### DIFF
--- a/dashboard/studio.js
+++ b/dashboard/studio.js
@@ -187,6 +187,28 @@
         }
       } else if (d.type === "step_error") {
         const out = document.getElementById(`rs-out-${d.i}`); if (out) out.innerHTML += `<div class="rs-err">${ic("triangle-alert", { cls: "ic-warn" })} ${esc(d.content)}</div>`;
+      } else if (d.type === "step_model") {
+        // Router chọn model khác model mặc định của agent - nói rõ để khỏi ngờ ngợ.
+        const div = stepDivs[d.i];
+        if (div) div.querySelector(".rs-head").insertAdjacentHTML("beforeend",
+          `<span class="rs-tool">${ic("settings")} model: ${esc(d.model)}</span>`);
+      } else if (d.type === "resume") {
+        stepsEl.insertAdjacentHTML("beforeend", `<div class="run-info">${ic("loader")} Chạy tiếp, giữ lại ${d.reused} bước đã xong</div>`);
+      } else if (d.type === "replan") {
+        stepsEl.insertAdjacentHTML("beforeend", `<div class="run-info">${ic("search")} Agent lập thêm ${(d.added || []).length} bước (vòng ${d.round})</div>`);
+      } else if (d.type === "wait_user") {
+        // Dừng chờ duyệt KHÔNG được trông giống bị sập: phải nói rõ đang chờ gì.
+        es.close();
+        endRun();
+        stepsEl.insertAdjacentHTML("beforeend", `<div class="run-info">${ic("triangle-alert", { cls: "ic-warn" })} Workflow dừng chờ anh duyệt bước "${esc(d.node || "")}"${d.prompt ? ": " + esc(d.prompt) : ""}</div>`);
+        stepsEl.scrollTop = stepsEl.scrollHeight;
+      } else if (d.type === "escalation") {
+        stepsEl.insertAdjacentHTML("beforeend", `<div class="run-info">${ic("triangle-alert", { cls: "ic-warn" })} Agent dừng và chuyển lại cho anh: ${esc(d.reason || "")}</div>`);
+      } else if (d.type === "error") {
+        es.close();
+        endRun();
+        stepsEl.insertAdjacentHTML("beforeend", `<div class="run-info">${ic("circle-x", { cls: "ic-err" })} ${esc(d.content || "Workflow dừng vì lỗi")}</div>`);
+        stepsEl.scrollTop = stepsEl.scrollHeight;
       } else if (d.type === "done") {
         es.close();
         endRun();

--- a/docs/dev/2026-08-adaptive-context-runtime-spec.md
+++ b/docs/dev/2026-08-adaptive-context-runtime-spec.md
@@ -1982,6 +1982,28 @@ Rollback: tắt agent task mới; workflow deterministic vẫn hoạt động.
 
 Đây là phase cuối vì model switching làm tăng mạnh số biến khi debug.
 
+Trạng thái code ngày 2026-08-02: **hoàn tất, chưa bật production**. `model_router_canary`
+mặc định allocation `0` và danh sách `models` rỗng, nên router luôn trả `keep` và model
+người dùng chọn ở trang Models vẫn là model chạy thật.
+
+Router làm việc theo thứ tự CỨNG: **lọc trước, xếp hạng sau**. Ứng viên thiếu một năng lực
+bắt buộc, vượt cửa sổ context, bị chính sách dữ liệu cấm, chậm quá deadline hay đắt quá
+ngân sách bước đều bị loại hẳn - không có điểm số nào cứu được. Rẻ hơn chỉ là tiêu chí xếp
+hạng GIỮA những ứng viên đã đủ năng lực. Đó là cách diễn đạt bằng code của luật mục 9.3.
+
+Hai quyết định đáng ghi lại:
+
+- **Không đoán năng lực theo tên model.** Rule không khai `supports: ["vision"]` thì model
+  đó không nhận ảnh, kể cả khi tên nó là `gpt-4o-super-vision-pro`. Đoán mò là cách chắc
+  chắn để một ngày nào đó gửi ảnh vào một model mù. Rule thiếu giá thật hoặc thiếu cửa sổ
+  context bị loại khỏi danh sách ứng viên, không được đoán bù.
+- **Không ai đủ năng lực thì GIỮ NGUYÊN model người dùng chọn**, không hạ tiêu chuẩn để có
+  cái mà chạy. Cờ `downgrade` tách riêng khỏi `priority`: `priority` là thứ tự xếp hạng,
+  còn `downgrade` là rào an toàn cho bước rủi ro cao.
+
+Chưa làm trong phase này: reliability live (hiện là số người vận hành khai, chưa tự học từ
+lỗi quan sát được) và validator bằng model.
+
 Thay đổi:
 
 - ModelSource đầy đủ và live reliability/quota profile.

--- a/docs/dev/2026-08-adaptive-context-runtime-spec.md
+++ b/docs/dev/2026-08-adaptive-context-runtime-spec.md
@@ -2001,8 +2001,32 @@ Hai quyết định đáng ghi lại:
   cái mà chạy. Cờ `downgrade` tách riêng khỏi `priority`: `priority` là thứ tự xếp hạng,
   còn `downgrade` là rào an toàn cho bước rủi ro cao.
 
+Router được nối vào việc chọn model cho từng bước workflow. Engine workflow chỉ chạy được
+CLI, nên có hai guard ở ranh giới: rule trỏ sang provider API thì giữ nguyên model của agent
+(không im lặng chạy model khác với thứ đã quyết), và route sang họ Codex mà model không phải
+model Codex cũng bị từ chối. Kích thước prompt thật được đưa vào request, nếu không bộ lọc
+cửa sổ context vô hiệu và prompt dài vẫn lọt vào model cửa sổ nhỏ.
+
 Chưa làm trong phase này: reliability live (hiện là số người vận hành khai, chưa tự học từ
 lỗi quan sát được) và validator bằng model.
+
+### Bài học tích hợp, ghi lại cho các thay đổi sau
+
+Phase 10-12 sinh ra năm trạng thái mới (`wait_user`, `replan`, `escalation`, `resume`,
+`step_model`) và bốn lỗi tích hợp - tất cả đều là **code đúng, test xanh, nhưng không nối
+được với thứ nó phục vụ**:
+
+- Router viết xong mà không có ai gọi.
+- Event bước thiếu trường chỉ số nên Studio lặng lẽ vứt phần chữ đang chạy.
+- Studio không có nhánh cho trạng thái mới, nên workflow dừng chờ duyệt trông y hệt bị sập.
+- Dispatcher Kanban không bắt `wait_user`, nên task chờ duyệt bị chấm HOÀN THÀNH với kết quả
+  rỗng và việc cần người biến mất; đồng thời trace ghi "đang chờ người" thành `FAILED`, làm
+  lệch chính các chỉ số dùng làm điều kiện qua phase.
+
+Test đơn vị mù với họ lỗi này vì nó chỉ kiểm phần mình viết. Thứ bắt được chúng là đi NGƯỢC
+từ phía tiêu thụ: ai gọi cái này, cái này hiện ra ở đâu, ai đọc trạng thái này. Vì vậy đã
+thêm một test đối chiếu hai chiều: mọi loại event runtime phát ra đều phải có nhánh xử lý
+trong `studio.js`. Thay đổi sau nào thêm trạng thái mới mà quên phía hiển thị sẽ đỏ ngay.
 
 Thay đổi:
 

--- a/server/config.py
+++ b/server/config.py
@@ -213,6 +213,22 @@ _DEFAULT = {
             "max_nodes_per_replan": 3,
             "failure_repeat_limit": 2,
         },
+        # Phase 12: chọn model theo từng bước. Lọc năng lực TRƯỚC, xếp hạng giá SAU -
+        # rẻ hơn không bao giờ thắng nếu thiếu năng lực bắt buộc (spec mục 9.3).
+        # Không đoán năng lực theo tên model: rule nào không khai `supports` thì coi
+        # như không có năng lực đó. Danh sách rỗng = giữ nguyên model người dùng chọn.
+        "model_router_canary": {
+            "policy_version": "model-router-canary-v1",
+            "allocation_basis_points": 0,
+            "salt": "model-router-canary-v1",
+            "step_kinds": ["model_step"],
+            "allow_downgrade_on_risk": False,
+            # Ví dụ một rule: {"id":"...", "provider":"groq", "model":"llama-3.3",
+            #  "supports":["tools"], "context_window":131072,
+            #  "input_cost_per_million":0.59, "output_cost_per_million":0.79,
+            #  "latency_hint_ms":1200, "reliability":0.99, "data_classes":[]}
+            "models": [],
+        },
         # Phase 8 dùng hard quota operator khai báo; không đoán TPM/context theo tên model.
         # Có thể để trống để dùng quota_profiles của Fast Path ở trên.
         "context_sources": {"quota_profiles": []},

--- a/server/main.py
+++ b/server/main.py
@@ -4586,9 +4586,13 @@ async def execute_workflow_graph(brain, slug, input="", tools=None, session_id="
                 agent_result = await runner.run(
                     trace, graph, input or "", session_id or f"wf:{slug}",
                     node_executor, planner, sink)
+                # Giữ nguyên trạng thái thật. Gộp "đang chờ người duyệt" hay "đã
+                # chuyển lại cho người" thành FAILED là ghi sai vào trace: chúng là
+                # kết cục BÌNH THƯỜNG, không phải hỏng.
                 return workflow_runtime.WorkflowRunResult(
-                    "COMPLETED" if agent_result.status == "COMPLETED" else "FAILED",
-                    agent_result.output, agent_result.stop_reason, agent_result.task_id)
+                    agent_result.status, agent_result.output,
+                    agent_result.stop_reason, agent_result.task_id,
+                    pending_node_id=agent_result.output_node_id)
             return await canary.run(trace, graph, input or "", session_id or f"wf:{slug}",
                                     node_executor, sink)
         finally:
@@ -4601,8 +4605,13 @@ async def execute_workflow_graph(brain, slug, input="", tools=None, session_id="
             break
         yield event
     result = await task
+    # ESCALATED và STOPPED là dừng có chủ đích, không phải lỗi runtime.
     _CONTEXT_RUNTIME.finish(
-        trace, "COMPLETED" if result.status == "COMPLETED" else "FAILED", result.stop_reason)
+        trace,
+        {"COMPLETED": "COMPLETED", "WAITING_USER": "WAITING_USER",
+         "ESCALATED": "COMPLETED_WITH_ERROR", "STOPPED": "COMPLETED_WITH_ERROR"}.get(
+            result.status, "FAILED"),
+        result.stop_reason)
     if result.status == "WAITING_USER":
         yield {"type": "wait_user", "node": result.pending_node_id,
                "task_id": result.task_id, "reason": result.stop_reason}

--- a/server/main.py
+++ b/server/main.py
@@ -4414,10 +4414,15 @@ async def _run_workflow_step(node, prompt, mk, agent_sysprompt, sink, router=Non
     Dùng chung cho cả hai đường. `sink` nhận event để đường graph đẩy ra SSE y như cũ.
     """
     agent_name, sysprompt, agent_model = agent_sysprompt(node.agent)
+    # Studio định vị chỗ đổ chữ bằng CHỈ SỐ bước, không phải id node. Thiếu `i` thì
+    # event vẫn phát ra nhưng giao diện lặng lẽ vứt đi - người xem thấy bước chạy và
+    # bước xong mà không thấy chữ nào.
+    index = int((node.metadata or {}).get("legacy_index",
+                (node.metadata or {}).get("declared_index", 0)) or 0)
     routed_model, route_reason = _route_step_model(router, prompt, agent_model, session_id)
     if routed_model != agent_model:
-        await sink({"type": "step_model", "node": node.id, "model": routed_model,
-                    "reason": route_reason})
+        await sink({"type": "step_model", "i": index, "node": node.id,
+                    "model": routed_model, "reason": route_reason})
         agent_model = routed_model
     cur_prompt = prompt
     out = ""
@@ -4428,17 +4433,21 @@ async def _run_workflow_step(node, prompt, mk, agent_sysprompt, sink, router=Non
         out = ""
         async for ev in gcli.query(cur_prompt):
             if ev["type"] == "text":
-                await sink({"type": "step_text", "node": node.id, "content": ev["content"]})
+                await sink({"type": "step_text", "i": index, "node": node.id,
+                            "content": ev["content"]})
             elif ev["type"] == "tool_call":
-                await sink({"type": "step_tool", "node": node.id, "tool": ev["name"]})
+                await sink({"type": "step_tool", "i": index, "node": node.id,
+                            "tool": ev["name"]})
             elif ev["type"] == "final":
                 out = ev.get("content") or out
             elif ev["type"] == "error":
-                await sink({"type": "step_error", "node": node.id, "content": ev["content"]})
+                await sink({"type": "step_error", "i": index, "node": node.id,
+                            "content": ev["content"]})
         if not node.verify_agent:
             break
         v_name, v_body, v_model = agent_sysprompt(node.verify_agent)
-        await sink({"type": "step_verify", "node": node.id, "agent": v_name, "attempt": attempt})
+        await sink({"type": "step_verify", "i": index, "node": node.id,
+                    "agent": v_name, "attempt": attempt})
         v_sys = (
             v_body + "\n\nVAI TRÒ KIỂM CHỨNG: Bạn là người ĐÁNH GIÁ độc lập. "
             "Mặc định GIẢ ĐỊNH kết quả dưới đây ĐANG SAI và phải tự chứng minh. "
@@ -4467,13 +4476,13 @@ async def _run_workflow_step(node, prompt, mk, agent_sysprompt, sink, router=Non
         passed = bool(verdict.get("pass", True))
         reason = verdict.get("reason", "")
         fixes = verdict.get("fixes", "")
-        await sink({"type": "step_verify_result", "node": node.id, "passed": passed,
+        await sink({"type": "step_verify_result", "i": index, "node": node.id, "passed": passed,
                     "reason": reason, "attempt": attempt})
         verified = passed
         if passed or attempt >= node.max_retries:
             break
         attempt += 1
-        await sink({"type": "step_retry", "node": node.id, "attempt": attempt})
+        await sink({"type": "step_retry", "i": index, "node": node.id, "attempt": attempt})
         cur_prompt = (
             f"{prompt}\n\n# KẾT QUẢ LẦN TRƯỚC (bị kiểm chứng đánh giá CHƯA ĐẠT):\n{out[:8000]}\n\n"
             f"# PHẢN HỒI KIỂM CHỨNG:\n- Vấn đề: {reason}\n- Cần sửa: {fixes}\n"

--- a/server/main.py
+++ b/server/main.py
@@ -72,6 +72,7 @@ import readonly_path_runtime # Phase 6: exact-schema, two-round read-only canary
 import readonly_orchestrator # Phase 7: checkpointed multi-round read-only DAG
 import adaptive_context_runtime # Phase 8: state + sourced memory + lazy skill canaries
 import agent_runtime           # Phase 11: agent = workflow có quyền replan trong quyền đã cấp
+import model_router           # Phase 12: chọn model theo từng bước, lọc năng lực trước
 import workflow_graph          # Phase 10: workflow -> capability graph (thuần dữ liệu)
 import workflow_runtime        # Phase 10: chạy graph có checkpoint/resume
 import write_path_runtime    # Phase 9: write có xác nhận, idempotency và reconcile
@@ -4356,12 +4357,57 @@ async def usage_refresh():
         return JSONResponse({"error": str(e)}, status_code=500)
 
 
-async def _run_workflow_step(node, prompt, mk, agent_sysprompt, sink):
+# Engine của workflow chỉ chạy được CLI (Claude hoặc Codex). Router có thể khai model
+# của provider API, nhưng ở đây không với tới được, nên chỉ nhận đúng hai họ này.
+_WORKFLOW_ROUTABLE_PROVIDERS = {
+    "cli": "claude", "claude": "claude", "anthropic-cli": "claude",
+    "codex": "codex", "openai-oauth": "codex",
+}
+
+
+def _route_step_model(router, node, agent_model, session_id):
+    """Chọn model cho MỘT bước. Không route được thì giữ nguyên model của agent.
+
+    Guard quan trọng: router có thể trỏ sang provider mà engine workflow không gọi
+    được. Im lặng dùng model đó là chạy sai model so với thứ đã quyết.
+    """
+    if router is None:
+        return agent_model, ""
+    try:
+        decision = router.route(
+            model_router.RoutingRequest(
+                step_kind="model_step",
+                requires=model_router.requirements_for(
+                    "model_step", needs_tools=True),
+                risk="none",
+            ),
+            session_id or "workflow",
+            current_model=agent_model or "",
+        )
+    except Exception:
+        return agent_model, ""
+    if decision.action != "route":
+        return agent_model, decision.reason
+    family = _WORKFLOW_ROUTABLE_PROVIDERS.get(decision.provider)
+    if family is None:
+        return agent_model, "provider_not_reachable_from_workflow_engine"
+    if family == "codex" and not _is_codex_model(decision.model):
+        return agent_model, "routed_model_not_valid_for_codex"
+    return decision.model, decision.reason
+
+
+async def _run_workflow_step(node, prompt, mk, agent_sysprompt, sink, router=None,
+                             session_id=""):
     """Chạy ĐÚNG một bước theo đúng ngữ nghĩa runner cũ: agent, kiểm chứng, retry.
 
     Dùng chung cho cả hai đường. `sink` nhận event để đường graph đẩy ra SSE y như cũ.
     """
     agent_name, sysprompt, agent_model = agent_sysprompt(node.agent)
+    routed_model, route_reason = _route_step_model(router, node, agent_model, session_id)
+    if routed_model != agent_model:
+        await sink({"type": "step_model", "node": node.id, "model": routed_model,
+                    "reason": route_reason})
+        agent_model = routed_model
     cur_prompt = prompt
     out = ""
     verified = None
@@ -4498,7 +4544,10 @@ async def execute_workflow_graph(brain, slug, input="", tools=None, session_id="
             # Phase 10 chỉ tự chạy model step. Node capability/workflow con do tầng
             # runtime quyết định; node ghi đã dừng hỏi trước khi tới đây.
             return {"output": "", "error": f"node_kind_not_executable:{node.kind}"}
-        return await _run_workflow_step(node, prompt, mk, agent_sysprompt, sink)
+        return await _run_workflow_step(
+            node, prompt, mk, agent_sysprompt, sink,
+            router=model_router.ModelRouter(cfgmod.read_settings),
+            session_id=session_id or f"wf:{slug}")
 
     async def planner(objective, summary, granted):
         """Phase 11 mặc định KHÔNG tự đề xuất gì.

--- a/server/main.py
+++ b/server/main.py
@@ -4359,20 +4359,29 @@ async def usage_refresh():
 
 # Engine của workflow chỉ chạy được CLI (Claude hoặc Codex). Router có thể khai model
 # của provider API, nhưng ở đây không với tới được, nên chỉ nhận đúng hai họ này.
+# Dự trù output cho một bước workflow. Bảo thủ: thà loại một model sát trần còn hơn
+# route vào rồi tràn cửa sổ giữa chừng.
+_ROUTER_STEP_OUTPUT_RESERVE = 4000
+
 _WORKFLOW_ROUTABLE_PROVIDERS = {
     "cli": "claude", "claude": "claude", "anthropic-cli": "claude",
     "codex": "codex", "openai-oauth": "codex",
 }
 
 
-def _route_step_model(router, node, agent_model, session_id):
+def _route_step_model(router, prompt, agent_model, session_id):
     """Chọn model cho MỘT bước. Không route được thì giữ nguyên model của agent.
 
     Guard quan trọng: router có thể trỏ sang provider mà engine workflow không gọi
     được. Im lặng dùng model đó là chạy sai model so với thứ đã quyết.
+
+    Phải truyền KÍCH THƯỚC prompt thật, nếu không bộ lọc cửa sổ context vô hiệu và
+    một prompt dài vẫn lọt vào model cửa sổ nhỏ.
     """
     if router is None:
         return agent_model, ""
+    # Cùng heuristic ký tự/token với phần còn lại của runtime; ước lượng bảo thủ.
+    estimated = max(1, int(len(str(prompt or "")) / 3) + 1)
     try:
         decision = router.route(
             model_router.RoutingRequest(
@@ -4380,6 +4389,8 @@ def _route_step_model(router, node, agent_model, session_id):
                 requires=model_router.requirements_for(
                     "model_step", needs_tools=True),
                 risk="none",
+                estimated_input_tokens=estimated,
+                reserved_output_tokens=_ROUTER_STEP_OUTPUT_RESERVE,
             ),
             session_id or "workflow",
             current_model=agent_model or "",
@@ -4403,7 +4414,7 @@ async def _run_workflow_step(node, prompt, mk, agent_sysprompt, sink, router=Non
     Dùng chung cho cả hai đường. `sink` nhận event để đường graph đẩy ra SSE y như cũ.
     """
     agent_name, sysprompt, agent_model = agent_sysprompt(node.agent)
-    routed_model, route_reason = _route_step_model(router, node, agent_model, session_id)
+    routed_model, route_reason = _route_step_model(router, prompt, agent_model, session_id)
     if routed_model != agent_model:
         await sink({"type": "step_model", "node": node.id, "model": routed_model,
                     "reason": route_reason})

--- a/server/model_router.py
+++ b/server/model_router.py
@@ -1,0 +1,268 @@
+"""Adaptive Runtime Phase 12: chọn model theo từng bước.
+
+Spec để phase này cuối cùng vì đổi model làm tăng mạnh số biến khi debug. Nguyên tắc
+nặng nhất của mục 9.3 cũng chính là thứ dễ vi phạm nhất:
+
+    **Không đổi model chỉ để tiết kiệm nếu việc đổi làm mất năng lực cần thiết.**
+
+Nên router ở đây làm việc theo thứ tự cứng: LỌC trước, XẾP HẠNG sau. Ứng viên thiếu
+một năng lực bắt buộc, hoặc bị chính sách dữ liệu cấm, thì bị loại hẳn - không có
+điểm số nào cứu được nó. Rẻ hơn chỉ là tiêu chí xếp hạng giữa những ứng viên ĐÃ đủ
+năng lực.
+
+Router không tự đoán năng lực theo tên model. Cũng như quota ở các phase trước, mọi
+thứ đều do người vận hành khai; không khai thì không có ứng viên nào và ta giữ nguyên
+model người dùng đã chọn. Đoán mò "gpt-4 chắc là có vision" là cách chắc chắn để một
+ngày nào đó gửi ảnh vào một model mù.
+"""
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+ROUTER_POLICY_VERSION = "model-router-canary-v1"
+
+# Năng lực có thể bắt buộc cho một bước. Thiếu là loại, không phải trừ điểm.
+CAPABILITY_FLAGS = ("tools", "vision", "reasoning", "parallel_tools", "prompt_cache")
+
+
+def _int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return int(default)
+
+
+def _float(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+        return parsed if parsed == parsed and parsed not in (float("inf"), float("-inf")) else float(default)
+    except (TypeError, ValueError, OverflowError):
+        return float(default)
+
+
+@dataclass(frozen=True)
+class ModelCandidate:
+    """Một model người vận hành khai là dùng được, kèm năng lực và giá thật."""
+    id: str
+    provider: str
+    model: str
+    supports: frozenset[str]
+    context_window: int
+    input_cost_per_million: float
+    output_cost_per_million: float
+    latency_hint_ms: int
+    reliability: float
+    data_classes: frozenset[str]
+    priority: int
+    # Cờ RIÊNG cho "đây là model hạng thấp hơn". Không dùng chung với `priority`:
+    # priority là thứ tự xếp hạng, còn cái này là rào an toàn cho bước rủi ro.
+    is_downgrade: bool
+
+    @classmethod
+    def from_rule(cls, raw: dict, index: int) -> Optional["ModelCandidate"]:
+        provider = str(raw.get("provider") or "").strip().casefold()
+        model = str(raw.get("model") or "").strip()
+        if not provider or not model:
+            return None
+        input_cost = _float(raw.get("input_cost_per_million"), -1.0)
+        output_cost = _float(raw.get("output_cost_per_million"), -1.0)
+        context = _int(raw.get("context_window"), 0)
+        # Thiếu giá hoặc thiếu cửa sổ context thì không xếp hạng nổi -> bỏ, fail-closed.
+        if input_cost < 0 or output_cost < 0 or context <= 0:
+            return None
+        supports = {str(x).strip().casefold() for x in (raw.get("supports") or [])}
+        return cls(
+            id=str(raw.get("id") or f"model-rule-{index + 1}")[:120],
+            provider=provider, model=model,
+            supports=frozenset(x for x in supports if x in CAPABILITY_FLAGS),
+            context_window=context,
+            input_cost_per_million=input_cost,
+            output_cost_per_million=output_cost,
+            latency_hint_ms=max(0, _int(raw.get("latency_hint_ms"), 0)),
+            reliability=max(0.0, min(_float(raw.get("reliability"), 1.0), 1.0)),
+            # Lớp dữ liệu model này được phép nhận. Rỗng = chỉ nhận dữ liệu thường.
+            data_classes=frozenset(
+                str(x).strip().casefold() for x in (raw.get("data_classes") or [])),
+            priority=_int(raw.get("priority"), 0),
+            is_downgrade=bool(raw.get("downgrade", False)),
+        )
+
+
+@dataclass(frozen=True)
+class RoutingRequest:
+    """Yêu cầu của MỘT bước, không phải của cả task."""
+    step_kind: str = "model_step"
+    requires: frozenset[str] = frozenset()
+    estimated_input_tokens: int = 0
+    reserved_output_tokens: int = 0
+    data_class: str = ""
+    risk: str = "none"
+    max_cost_usd: Optional[float] = None
+    deadline_ms: Optional[int] = None
+    min_reliability: float = 0.0
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    action: str            # "route" | "keep" | "reject"
+    provider: str = ""
+    model: str = ""
+    rule_id: str = ""
+    reason: str = ""
+    estimated_cost_usd: float = 0.0
+    rejected: dict = field(default_factory=dict)
+    considered: int = 0
+    policy_version: str = ROUTER_POLICY_VERSION
+
+
+@dataclass(frozen=True)
+class RouterPolicy:
+    mode: str
+    allocation_basis_points: int
+    salt: str
+    candidates: tuple[ModelCandidate, ...]
+    allow_downgrade_on_risk: bool
+    step_kinds: tuple[str, ...]
+    version: str
+
+    @classmethod
+    def from_settings(cls, settings: dict) -> "RouterPolicy":
+        runtime = (settings or {}).get("context_runtime") or {}
+        runtime = runtime if isinstance(runtime, dict) else {}
+        raw = runtime.get("model_router_canary")
+        raw = raw if isinstance(raw, dict) else {}
+        candidates = []
+        for index, item in enumerate(raw.get("models") or []):
+            if isinstance(item, dict):
+                candidate = ModelCandidate.from_rule(item, index)
+                if candidate is not None:
+                    candidates.append(candidate)
+        return cls(
+            mode=str(raw.get("mode", runtime.get("mode", "off"))).casefold(),
+            allocation_basis_points=max(0, min(_int(raw.get("allocation_basis_points"), 0), 10_000)),
+            salt=str(raw.get("salt") or ROUTER_POLICY_VERSION),
+            candidates=tuple(candidates),
+            # Bước rủi ro cao mặc định KHÔNG được đổi sang model rẻ hơn.
+            allow_downgrade_on_risk=bool(raw.get("allow_downgrade_on_risk", False)),
+            step_kinds=tuple(str(x) for x in (raw.get("step_kinds") or ["model_step"])),
+            version=str(raw.get("policy_version") or ROUTER_POLICY_VERSION)[:120],
+        )
+
+    def admits(self, session_id: str) -> tuple[bool, int, str]:
+        from fast_path_runtime import stable_bucket
+        bucket = stable_bucket(session_id, self.salt)
+        if self.mode not in ("canary", "on"):
+            return False, bucket, "mode_not_canary"
+        if bucket >= self.allocation_basis_points:
+            return False, bucket, "outside_allocation"
+        if not self.candidates:
+            return False, bucket, "no_model_rules_declared"
+        return True, bucket, "admitted"
+
+
+class ModelRouter:
+    """Lọc theo năng lực và chính sách TRƯỚC, rồi mới xếp hạng theo chi phí."""
+
+    def __init__(self, settings_reader: Callable[[], dict]):
+        self.settings_reader = settings_reader
+
+    def policy(self) -> RouterPolicy:
+        try:
+            return RouterPolicy.from_settings(self.settings_reader() or {})
+        except Exception:
+            return RouterPolicy.from_settings({})
+
+    @staticmethod
+    def _cost(candidate: ModelCandidate, request: RoutingRequest) -> float:
+        return (max(0, request.estimated_input_tokens) * candidate.input_cost_per_million
+                + max(0, request.reserved_output_tokens) * candidate.output_cost_per_million) / 1_000_000
+
+    def _reject_reason(self, candidate: ModelCandidate, request: RoutingRequest,
+                       policy: RouterPolicy) -> str:
+        """Lọc CỨNG. Trả mã lý do nếu loại; rỗng nếu ứng viên đi tiếp được."""
+        missing = sorted(request.requires - candidate.supports)
+        if missing:
+            # Đây là luật nặng nhất của mục 9.3: thiếu năng lực thì rẻ mấy cũng loại.
+            return f"missing_capability:{','.join(missing)}"
+        needed = max(0, request.estimated_input_tokens) + max(0, request.reserved_output_tokens)
+        if needed > candidate.context_window:
+            return "context_window_too_small"
+        if request.data_class and request.data_class.casefold() not in candidate.data_classes:
+            # Chính sách dữ liệu: model chưa được khai là nhận được lớp dữ liệu này
+            # thì không bao giờ được nhận, kể cả khi nó là ứng viên duy nhất.
+            return f"data_class_not_allowed:{request.data_class[:40]}"
+        if candidate.reliability < request.min_reliability:
+            return "reliability_below_requirement"
+        if (request.deadline_ms is not None and candidate.latency_hint_ms
+                and candidate.latency_hint_ms > request.deadline_ms):
+            return "latency_hint_exceeds_deadline"
+        cost = self._cost(candidate, request)
+        if request.max_cost_usd is not None and cost > request.max_cost_usd:
+            return "cost_above_step_budget"
+        if (request.risk in ("write", "dangerous") and not policy.allow_downgrade_on_risk
+                and candidate.is_downgrade):
+            return "downgrade_not_allowed_for_risky_step"
+        return ""
+
+    def route(self, request: RoutingRequest, session_id: str,
+              current_provider: str = "", current_model: str = "") -> RoutingDecision:
+        policy = self.policy()
+        admitted, _bucket, reason = policy.admits(session_id)
+        if not admitted:
+            return RoutingDecision("keep", current_provider, current_model,
+                                   reason=reason, policy_version=policy.version)
+        if request.step_kind not in policy.step_kinds:
+            return RoutingDecision("keep", current_provider, current_model,
+                                   reason="step_kind_not_routed",
+                                   policy_version=policy.version)
+
+        rejected: dict[str, str] = {}
+        eligible: list[ModelCandidate] = []
+        for candidate in policy.candidates:
+            error = self._reject_reason(candidate, request, policy)
+            if error:
+                rejected[candidate.id] = error
+            else:
+                eligible.append(candidate)
+
+        if not eligible:
+            # Không ai đủ năng lực thì GIỮ NGUYÊN model người dùng đã chọn, không hạ
+            # tiêu chuẩn để có cái mà chạy.
+            return RoutingDecision("keep", current_provider, current_model,
+                                   reason="no_eligible_model", rejected=rejected,
+                                   considered=len(policy.candidates),
+                                   policy_version=policy.version)
+
+        # Xếp hạng CHỈ trong số đã đủ năng lực: ưu tiên khai báo, rồi rẻ, rồi nhanh,
+        # rồi ổn định. Tie-break bằng id để quyết định deterministic.
+        eligible.sort(key=lambda c: (
+            -c.priority,
+            self._cost(c, request),
+            c.latency_hint_ms,
+            -c.reliability,
+            c.id,
+        ))
+        best = eligible[0]
+        cost = self._cost(best, request)
+        if best.provider == (current_provider or "").casefold() and best.model == current_model:
+            return RoutingDecision("keep", best.provider, best.model, best.id,
+                                   "already_on_best_model", cost, rejected,
+                                   len(policy.candidates), policy.version)
+        return RoutingDecision("route", best.provider, best.model, best.id,
+                               "best_eligible", cost, rejected,
+                               len(policy.candidates), policy.version)
+
+
+def requirements_for(step_kind: str, *, needs_tools: bool = False,
+                     needs_vision: bool = False, needs_reasoning: bool = False) -> frozenset[str]:
+    """Suy năng lực bắt buộc từ nhu cầu THẬT của bước, không đoán theo tên model."""
+    required = set()
+    if needs_tools:
+        required.add("tools")
+    if needs_vision:
+        required.add("vision")
+    if needs_reasoning:
+        required.add("reasoning")
+    return frozenset(required)

--- a/server/tasks.py
+++ b/server/tasks.py
@@ -645,6 +645,19 @@ nói rõ đã được phép tự hành động; nếu không thì để auto đ
                     kind = event.get("type")
                     if kind == "done":
                         result = event.get("result") or result
+                    elif kind == "wait_user":
+                        # Workflow dừng chờ người duyệt. Không có nhánh này thì task bị
+                        # chấm là XONG với kết quả rỗng, và việc cần duyệt biến mất.
+                        result = (result or "") + (
+                            "\n[[NEEDS_INPUT]] Workflow dừng chờ duyệt bước "
+                            f"'{event.get('node') or '?'}'"
+                            f"{': ' + str(event.get('prompt')) if event.get('prompt') else ''}"
+                        )
+                    elif kind == "escalation":
+                        result = (result or "") + (
+                            "\n[[NEEDS_INPUT]] Agent chuyển lại cho người: "
+                            f"{event.get('reason') or 'không rõ lý do'}"
+                        )
                     elif kind in ("error", "step_error"):
                         error = event.get("content") or error
             except Exception as exc:

--- a/tests/python/test_adaptive_runtime_hardening.py
+++ b/tests/python/test_adaptive_runtime_hardening.py
@@ -396,9 +396,13 @@ def test_repository_defaults_activate_no_canary_path(tmp_path):
     import copy
     import asyncio
     import config as cfgmod
+    import agent_runtime
     import fast_path_runtime
+    import model_router
     import readonly_path_runtime
     import readonly_orchestrator
+    import workflow_graph
+    import workflow_runtime
     import write_path_runtime
     from adaptive_context_runtime import AdaptiveContextCanary
     from capability_executor import CapabilityExecutor
@@ -458,7 +462,20 @@ def test_repository_defaults_activate_no_canary_path(tmp_path):
             tmp_path / "st", registry, compiler, runtime, lambda: settings
         ).prepare(trace, objective, brain, "sid", [], "dashboard", "groq",
                   "llama-3.3", "api", lambda memory, skills: "base"),
+        # Phase 10-12. Test này là hàng rào cuối cùng chống việc vô tình bật một
+        # đường canary ở mặc định, nên nó phải phủ HẾT, không được rơi rớt phase nào.
+        "workflow": workflow_runtime.WorkflowCanary(
+            runtime, lambda: settings
+        ).prepare(trace, workflow_graph.compile_workflow(
+            {"name": "demo", "steps": [{"agent": "a", "task": "t"}]}, "demo"), "sid"),
     }
+    agent_admitted, _b, agent_reason = agent_runtime.AgentPolicy.from_settings(
+        settings).admits("demo", "sid")
+    assert not agent_admitted, f"agent canary bật ở mặc định: {agent_reason}"
+    routed = model_router.ModelRouter(lambda: settings).route(
+        model_router.RoutingRequest(), "sid", "groq", "model-cua-user")
+    assert routed.action == "keep" and routed.model == "model-cua-user", (
+        "model router đổi model ở mặc định")
     for name, plan in plans.items():
         assert plan.action in ("not_applicable", "legacy"), (name, plan.action, plan.reason)
 

--- a/tests/python/test_agent_replan_phase11.py
+++ b/tests/python/test_agent_replan_phase11.py
@@ -455,6 +455,66 @@ def test_repo_defaults_never_admit_the_agent_path(tmp_path, monkeypatch):
     assert calls == ["Tìm x"]
 
 
+def test_agent_pause_is_not_recorded_as_a_failure(tmp_path, monkeypatch):
+    """Chờ người duyệt là kết cục BÌNH THƯỜNG. Ghi FAILED vào trace là ghi sai.
+
+    Chạy thật execute_workflow_graph, không quét chuỗi source.
+    """
+    import asyncio as aio
+    import copy
+    import config as cfgmod
+    import main
+
+    settings = copy.deepcopy(cfgmod._DEFAULT)
+    settings["context_runtime"]["mode"] = "canary"
+    settings["context_runtime"]["workflow_canary"].update({
+        "allocation_basis_points": 10_000, "allowed_slugs": ["demo"],
+        "allow_write_nodes": True,
+    })
+
+    brain = tmp_path / "brain"
+    (brain / "workflows").mkdir(parents=True)
+    (brain / "agents").mkdir(parents=True)
+    # Node đầu là bước model, node sau là ghi -> chạy tới đó thì dừng hỏi.
+    (brain / "workflows" / "demo.md").write_text(
+        "---\ntype: workflow\nname: Demo\nslug: demo\nstatus: active\n"
+        "nodes:\n"
+        "  - id: a\n    kind: model_step\n    agent: researcher\n    task: 'soạn'\n"
+        "  - id: w\n    kind: capability\n    capability: mail_send\n"
+        "    effect: write\n    depends_on: [a]\n---\n", encoding="utf-8")
+    (brain / "agents" / "researcher.md").write_text(
+        "---\ntype: agent\nname: researcher\nslug: researcher\nrole: r\nskills: []\n---\nx\n",
+        encoding="utf-8")
+
+    class FakeEngine:
+        def __init__(self, *a, **k):
+            self.model = None
+
+        async def query(self, prompt):
+            yield {"type": "final", "content": "đã soạn"}
+
+    monkeypatch.setattr(main, "claude_engine", lambda **k: FakeEngine())
+    monkeypatch.setattr(main, "_brain_root", lambda b: str(brain))
+    monkeypatch.setattr(main, "_workflows_dir", lambda b: brain / "workflows")
+    monkeypatch.setattr(main, "_agents_dir", lambda b: brain / "agents")
+    monkeypatch.setattr(main, "_agent_memory", lambda b, s: "")
+    monkeypatch.setattr(main.system_sync, "ensure_synced", lambda *a, **k: None)
+    monkeypatch.setattr(main.system_sync, "mirror_skills", lambda *a, **k: None)
+    monkeypatch.setattr(main.cfgmod, "read_settings", lambda: settings)
+
+    recorded = []
+    monkeypatch.setattr(main._CONTEXT_RUNTIME, "finish",
+                        lambda trace, status="COMPLETED", reason="": recorded.append(status))
+
+    async def go():
+        return [x async for x in main.execute_workflow_graph(
+            "brain", "demo", "x", None, "sid-pause")]
+
+    events = aio.run(go())
+    assert any(x["type"] == "wait_user" for x in events), "phải báo đang chờ duyệt"
+    assert recorded == ["WAITING_USER"], f"trace ghi sai trạng thái: {recorded}"
+
+
 if __name__ == "__main__":
     import sys
     import pytest

--- a/tests/python/test_model_router_phase12.py
+++ b/tests/python/test_model_router_phase12.py
@@ -242,7 +242,7 @@ def test_router_never_picks_a_provider_the_workflow_engine_cannot_reach(monkeypa
     ])
     monkeypatch.setattr(main.cfgmod, "read_settings", lambda: settings)
     router = main.model_router.ModelRouter(lambda: settings)
-    model, reason = main._route_step_model(router, None, "sonnet", "sid")
+    model, reason = main._route_step_model(router, "prompt ngắn", "sonnet", "sid")
     assert model == "sonnet", "giữ nguyên model của agent"
     assert reason == "provider_not_reachable_from_workflow_engine"
 
@@ -256,7 +256,7 @@ def test_router_applies_a_reachable_cli_model(monkeypatch):
          "output_cost_per_million": 2.0},
     ])
     router = main.model_router.ModelRouter(lambda: settings)
-    model, _reason = main._route_step_model(router, None, "sonnet", "sid")
+    model, _reason = main._route_step_model(router, "prompt ngắn", "sonnet", "sid")
     assert model == "opus"
 
 
@@ -269,7 +269,7 @@ def test_router_refuses_a_codex_route_that_is_not_a_codex_model(monkeypatch):
          "input_cost_per_million": 1.0, "output_cost_per_million": 2.0},
     ])
     router = main.model_router.ModelRouter(lambda: settings)
-    model, reason = main._route_step_model(router, None, "sonnet", "sid")
+    model, reason = main._route_step_model(router, "prompt ngắn", "sonnet", "sid")
     assert model == "sonnet"
     assert reason == "routed_model_not_valid_for_codex"
 
@@ -281,7 +281,7 @@ def test_router_errors_keep_the_agent_model(monkeypatch):
         def route(self, *a, **k):
             raise RuntimeError("router hỏng")
 
-    model, reason = main._route_step_model(Boom(), None, "sonnet", "sid")
+    model, reason = main._route_step_model(Boom(), "prompt", "sonnet", "sid")
     assert model == "sonnet" and reason == ""
 
 
@@ -292,8 +292,30 @@ def test_defaults_leave_every_workflow_step_on_the_agent_model(monkeypatch):
 
     settings = copy.deepcopy(cfgmod._DEFAULT)
     router = main.model_router.ModelRouter(lambda: settings)
-    model, reason = main._route_step_model(router, None, "sonnet", "sid")
+    model, reason = main._route_step_model(router, "prompt ngắn", "sonnet", "sid")
     assert model == "sonnet" and reason == "mode_not_canary"
+
+
+def test_a_long_prompt_is_not_routed_into_a_small_context_model(monkeypatch):
+    """Bộ lọc cửa sổ context chỉ có tác dụng nếu ta ĐƯA cho nó kích thước thật."""
+    import main
+
+    settings = _router_settings([
+        # Cửa sổ phải lớn hơn dự trù output (4000), nếu không đến prompt rỗng cũng
+        # không vừa - fixture như vậy đo nhầm sang chuyện khác.
+        {"id": "nho", "provider": "anthropic-cli", "model": "cua-so-nho",
+         "supports": ["tools"], "context_window": 12_000,
+         "input_cost_per_million": 0.01, "output_cost_per_million": 0.02},
+    ])
+    router = main.model_router.ModelRouter(lambda: settings)
+
+    short_model, _ = main._route_step_model(router, "ngắn", "sonnet", "sid")
+    assert short_model == "cua-so-nho", "prompt ngắn thì vừa"
+
+    long_prompt = "x" * 200_000
+    long_model, reason = main._route_step_model(router, long_prompt, "sonnet", "sid")
+    assert long_model == "sonnet", "prompt dài phải giữ model của agent"
+    assert reason == "no_eligible_model"
 
 
 if __name__ == "__main__":

--- a/tests/python/test_model_router_phase12.py
+++ b/tests/python/test_model_router_phase12.py
@@ -221,6 +221,81 @@ def test_malformed_settings_fall_back_to_keeping_the_current_model():
         assert decision.action == "keep" and decision.model == "llama-3.3"
 
 
+# ----------------------------------------------- nối vào bước workflow
+
+def _router_settings(models, allocation=10_000):
+    return {"context_runtime": {"mode": "canary", "model_router_canary": {
+        "allocation_basis_points": allocation, "models": models}}}
+
+
+def test_router_never_picks_a_provider_the_workflow_engine_cannot_reach(monkeypatch):
+    """Router có thể khai model API, nhưng engine workflow chỉ chạy được CLI.
+
+    Im lặng dùng model đó là chạy sai model so với thứ đã quyết.
+    """
+    import main
+
+    settings = _router_settings([
+        {"id": "api", "provider": "groq", "model": "llama-3.3", "supports": ["tools"],
+         "context_window": 100_000, "input_cost_per_million": 0.1,
+         "output_cost_per_million": 0.2},
+    ])
+    monkeypatch.setattr(main.cfgmod, "read_settings", lambda: settings)
+    router = main.model_router.ModelRouter(lambda: settings)
+    model, reason = main._route_step_model(router, None, "sonnet", "sid")
+    assert model == "sonnet", "giữ nguyên model của agent"
+    assert reason == "provider_not_reachable_from_workflow_engine"
+
+
+def test_router_applies_a_reachable_cli_model(monkeypatch):
+    import main
+
+    settings = _router_settings([
+        {"id": "cli", "provider": "anthropic-cli", "model": "opus", "supports": ["tools"],
+         "context_window": 200_000, "input_cost_per_million": 1.0,
+         "output_cost_per_million": 2.0},
+    ])
+    router = main.model_router.ModelRouter(lambda: settings)
+    model, _reason = main._route_step_model(router, None, "sonnet", "sid")
+    assert model == "opus"
+
+
+def test_router_refuses_a_codex_route_that_is_not_a_codex_model(monkeypatch):
+    import main
+
+    settings = _router_settings([
+        {"id": "codex", "provider": "codex", "model": "claude-sonnet-4",
+         "supports": ["tools"], "context_window": 100_000,
+         "input_cost_per_million": 1.0, "output_cost_per_million": 2.0},
+    ])
+    router = main.model_router.ModelRouter(lambda: settings)
+    model, reason = main._route_step_model(router, None, "sonnet", "sid")
+    assert model == "sonnet"
+    assert reason == "routed_model_not_valid_for_codex"
+
+
+def test_router_errors_keep_the_agent_model(monkeypatch):
+    import main
+
+    class Boom:
+        def route(self, *a, **k):
+            raise RuntimeError("router hỏng")
+
+    model, reason = main._route_step_model(Boom(), None, "sonnet", "sid")
+    assert model == "sonnet" and reason == ""
+
+
+def test_defaults_leave_every_workflow_step_on_the_agent_model(monkeypatch):
+    import copy
+    import config as cfgmod
+    import main
+
+    settings = copy.deepcopy(cfgmod._DEFAULT)
+    router = main.model_router.ModelRouter(lambda: settings)
+    model, reason = main._route_step_model(router, None, "sonnet", "sid")
+    assert model == "sonnet" and reason == "mode_not_canary"
+
+
 if __name__ == "__main__":
     import sys
     import pytest

--- a/tests/python/test_model_router_phase12.py
+++ b/tests/python/test_model_router_phase12.py
@@ -1,0 +1,227 @@
+"""Phase 12: chọn model theo từng bước.
+
+Luật nặng nhất của spec mục 9.3: không đổi model chỉ để tiết kiệm nếu việc đổi làm
+mất năng lực cần thiết. Mọi hàng rào dưới đây đều được kiểm chứng ngược.
+"""
+from _paths import SERVER  # noqa: E402,F401
+
+from model_router import (ModelRouter, RouterPolicy, RoutingRequest,
+                          requirements_for)
+
+
+def _settings(models=None, allocation=10_000, allow_downgrade=False):
+    return {
+        "context_runtime": {
+            "mode": "canary",
+            "model_router_canary": {
+                "policy_version": "test-router-v1",
+                "allocation_basis_points": allocation,
+                "allow_downgrade_on_risk": allow_downgrade,
+                "models": models if models is not None else [
+                    {"id": "re", "provider": "groq", "model": "llama-re",
+                     "supports": [], "context_window": 100_000,
+                     "input_cost_per_million": 0.05, "output_cost_per_million": 0.08},
+                    {"id": "manh", "provider": "anthropic-api", "model": "claude-manh",
+                     "supports": ["tools", "vision", "reasoning"],
+                     "context_window": 200_000,
+                     "input_cost_per_million": 3.0, "output_cost_per_million": 15.0},
+                ],
+            },
+        }
+    }
+
+
+def _router(settings=None):
+    settings = settings or _settings()
+    return ModelRouter(lambda: settings)
+
+
+# ----------------------------------------------- lọc năng lực trước, giá sau
+
+def test_cheaper_model_never_wins_when_it_lacks_a_required_capability():
+    """Luật trung tâm của mục 9.3."""
+    router = _router()
+    # Bước không cần gì: chọn model rẻ.
+    plain = router.route(RoutingRequest(estimated_input_tokens=1000,
+                                        reserved_output_tokens=500), "sid")
+    assert plain.action == "route" and plain.model == "llama-re"
+
+    # Bước cần tool: model rẻ KHÔNG có tool nên bị loại hẳn dù rẻ hơn 60 lần.
+    with_tools = router.route(RoutingRequest(
+        requires=requirements_for("model_step", needs_tools=True),
+        estimated_input_tokens=1000, reserved_output_tokens=500), "sid")
+    assert with_tools.action == "route" and with_tools.model == "claude-manh"
+    assert with_tools.rejected["re"].startswith("missing_capability:tools")
+
+
+def test_vision_requirement_is_not_guessed_from_the_model_name():
+    """Model không KHAI vision thì không bao giờ nhận ảnh, dù tên nghe có vẻ xịn."""
+    router = _router(_settings(models=[
+        {"id": "nghe-xin", "provider": "openai", "model": "gpt-4o-super-vision-pro",
+         "supports": [], "context_window": 100_000,
+         "input_cost_per_million": 1.0, "output_cost_per_million": 2.0},
+    ]))
+    decision = router.route(RoutingRequest(
+        requires=requirements_for("model_step", needs_vision=True),
+        estimated_input_tokens=100, reserved_output_tokens=100), "sid")
+    assert decision.action == "keep" and decision.reason == "no_eligible_model"
+    assert "missing_capability:vision" in decision.rejected["nghe-xin"]
+
+
+def test_no_eligible_model_keeps_the_user_choice_instead_of_lowering_the_bar():
+    router = _router()
+    decision = router.route(RoutingRequest(
+        requires=frozenset({"tools", "vision", "reasoning", "parallel_tools"}),
+        estimated_input_tokens=100, reserved_output_tokens=100), "sid",
+        current_provider="groq", current_model="model-cua-user")
+    assert decision.action == "keep"
+    assert decision.reason == "no_eligible_model"
+    assert decision.model == "model-cua-user"
+
+
+# ----------------------------------------------- chính sách dữ liệu
+
+def test_data_class_is_enforced_even_for_the_only_candidate():
+    router = _router(_settings(models=[
+        {"id": "duy-nhat", "provider": "groq", "model": "llama-re", "supports": [],
+         "context_window": 100_000, "input_cost_per_million": 0.01,
+         "output_cost_per_million": 0.02},
+    ]))
+    decision = router.route(RoutingRequest(
+        data_class="y-te", estimated_input_tokens=100, reserved_output_tokens=50), "sid")
+    assert decision.action == "keep"
+    assert "data_class_not_allowed" in decision.rejected["duy-nhat"]
+
+    allowed = _router(_settings(models=[
+        {"id": "duy-nhat", "provider": "groq", "model": "llama-re", "supports": [],
+         "context_window": 100_000, "input_cost_per_million": 0.01,
+         "output_cost_per_million": 0.02, "data_classes": ["y-te"]},
+    ]))
+    ok = allowed.route(RoutingRequest(
+        data_class="y-te", estimated_input_tokens=100, reserved_output_tokens=50), "sid")
+    assert ok.action == "route" and ok.model == "llama-re"
+
+
+# ----------------------------------------------- các ràng buộc còn lại
+
+def test_context_window_deadline_and_cost_are_hard_filters():
+    router = _router()
+    too_big = router.route(RoutingRequest(
+        estimated_input_tokens=150_000, reserved_output_tokens=1000), "sid")
+    assert too_big.action == "route" and too_big.model == "claude-manh"
+    assert too_big.rejected["re"] == "context_window_too_small"
+
+    slow = _router(_settings(models=[
+        {"id": "cham", "provider": "groq", "model": "llama-cham", "supports": [],
+         "context_window": 100_000, "input_cost_per_million": 0.01,
+         "output_cost_per_million": 0.02, "latency_hint_ms": 9000},
+    ]))
+    late = slow.route(RoutingRequest(deadline_ms=2000, estimated_input_tokens=10,
+                                     reserved_output_tokens=10), "sid")
+    assert late.action == "keep"
+    assert late.rejected["cham"] == "latency_hint_exceeds_deadline"
+
+    # Vừa cửa sổ context nhưng vượt ngân sách tiền của bước.
+    pricey = router.route(RoutingRequest(
+        requires=frozenset({"tools"}), estimated_input_tokens=100_000,
+        reserved_output_tokens=10_000, max_cost_usd=0.01), "sid")
+    assert pricey.action == "keep"
+    assert pricey.rejected["manh"] == "cost_above_step_budget"
+
+
+def test_risky_step_does_not_get_downgraded_by_default():
+    models = [
+        {"id": "re-yeu", "provider": "groq", "model": "llama-re", "supports": ["tools"],
+         "context_window": 100_000, "input_cost_per_million": 0.01,
+         "output_cost_per_million": 0.02, "downgrade": True},
+        {"id": "manh", "provider": "anthropic-api", "model": "claude-manh",
+         "supports": ["tools"], "context_window": 200_000,
+         "input_cost_per_million": 3.0, "output_cost_per_million": 15.0},
+    ]
+    strict = _router(_settings(models=models))
+    decision = strict.route(RoutingRequest(
+        requires=frozenset({"tools"}), risk="write",
+        estimated_input_tokens=100, reserved_output_tokens=100), "sid")
+    assert decision.model == "claude-manh"
+    assert decision.rejected["re-yeu"] == "downgrade_not_allowed_for_risky_step"
+
+    # Chỉ khi người vận hành khai rõ mới cho hạ.
+    lenient = _router(_settings(models=models, allow_downgrade=True))
+    allowed = lenient.route(RoutingRequest(
+        requires=frozenset({"tools"}), risk="write",
+        estimated_input_tokens=100, reserved_output_tokens=100), "sid")
+    assert allowed.model == "llama-re"
+
+
+def test_ranking_is_deterministic_and_priority_beats_price():
+    models = [
+        {"id": "b", "provider": "groq", "model": "m-b", "supports": [],
+         "context_window": 10_000, "input_cost_per_million": 1.0,
+         "output_cost_per_million": 1.0},
+        {"id": "a", "provider": "groq", "model": "m-a", "supports": [],
+         "context_window": 10_000, "input_cost_per_million": 1.0,
+         "output_cost_per_million": 1.0},
+    ]
+    router = _router(_settings(models=models))
+    request = RoutingRequest(estimated_input_tokens=100, reserved_output_tokens=100)
+    first = router.route(request, "sid")
+    # Giá bằng nhau -> tie-break bằng id, ổn định qua nhiều lần gọi.
+    assert first.model == "m-a"
+    assert all(router.route(request, "sid").model == "m-a" for _ in range(5))
+
+    with_priority = _router(_settings(models=[
+        {**models[0], "priority": 5}, models[1],
+    ]))
+    assert with_priority.route(request, "sid").model == "m-b"
+
+
+def test_already_on_the_best_model_is_reported_as_keep():
+    router = _router()
+    decision = router.route(
+        RoutingRequest(estimated_input_tokens=100, reserved_output_tokens=100),
+        "sid", current_provider="groq", current_model="llama-re")
+    assert decision.action == "keep" and decision.reason == "already_on_best_model"
+
+
+# ----------------------------------------------- khai báo thiếu là fail-closed
+
+def test_rules_without_real_price_or_context_are_dropped():
+    for bad in (
+        {"id": "x", "provider": "groq", "model": "m", "context_window": 1000},
+        {"id": "x", "provider": "groq", "model": "m", "input_cost_per_million": 1.0,
+         "output_cost_per_million": 1.0},
+        {"id": "x", "provider": "", "model": "m", "context_window": 1000,
+         "input_cost_per_million": 1.0, "output_cost_per_million": 1.0},
+    ):
+        policy = RouterPolicy.from_settings(_settings(models=[bad]))
+        assert policy.candidates == (), bad
+    decision = _router(_settings(models=[
+        {"id": "x", "provider": "groq", "model": "m", "context_window": 1000},
+    ])).route(RoutingRequest(), "sid", current_model="cua-user")
+    assert decision.action == "keep" and decision.reason == "no_model_rules_declared"
+
+
+def test_defaults_never_route(tmp_path):
+    import copy
+    import config as cfgmod
+
+    settings = copy.deepcopy(cfgmod._DEFAULT)
+    policy = RouterPolicy.from_settings(settings)
+    assert policy.allocation_basis_points == 0 and policy.candidates == ()
+    decision = ModelRouter(lambda: settings).route(
+        RoutingRequest(), "phiên bất kỳ", "groq", "llama-3.3")
+    assert decision.action == "keep" and decision.model == "llama-3.3"
+
+
+def test_malformed_settings_fall_back_to_keeping_the_current_model():
+    for broken in ({"context_runtime": "off"}, {"context_runtime": {"model_router_canary": 5}},
+                   {}, None):
+        decision = ModelRouter(lambda: broken).route(
+            RoutingRequest(), "sid", "groq", "llama-3.3")
+        assert decision.action == "keep" and decision.model == "llama-3.3"
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/python/test_workflow_graph_phase10.py
+++ b/tests/python/test_workflow_graph_phase10.py
@@ -630,6 +630,37 @@ def test_graph_path_events_carry_the_step_index_studio_needs(tmp_path, monkeypat
     assert {x["i"] for x in streamed if x["type"] == "step_text"} == {0, 1}
 
 
+def test_studio_handles_every_event_type_the_graph_path_emits():
+    """Event phát ra mà giao diện không xử lý = người dùng không thấy gì.
+
+    Đây đúng loại lỗi mà test phía server không bắt được, vì server vẫn phát đủ.
+    """
+    import re as _re
+    from pathlib import Path
+
+    studio = (Path(__file__).resolve().parents[2] / "dashboard" / "studio.js").read_text(
+        encoding="utf-8")
+    handled = set(_re.findall(r'd\.type === "([a-z_]+)"', studio))
+    # Mọi loại event mà execute_workflow_graph / workflow_runtime / agent_runtime phát.
+    emitted = {"start", "step_start", "step_text", "step_tool", "step_done",
+               "step_error", "step_verify", "step_verify_result", "step_retry",
+               "step_model", "resume", "replan", "wait_user", "escalation",
+               "error", "done"}
+    missing = emitted - handled
+    assert not missing, f"Studio chưa xử lý: {sorted(missing)}"
+
+
+def test_paused_workflow_is_not_shown_as_a_crash():
+    """Dừng chờ duyệt phải đóng stream VÀ nói rõ, không im lặng như bị sập."""
+    from pathlib import Path
+
+    studio = (Path(__file__).resolve().parents[2] / "dashboard" / "studio.js").read_text(
+        encoding="utf-8")
+    block = studio.split('d.type === "wait_user"', 1)[1].split("} else if", 1)[0]
+    assert "es.close()" in block and "endRun()" in block
+    assert "chờ anh duyệt" in block
+
+
 if __name__ == "__main__":
     import sys
     import pytest

--- a/tests/python/test_workflow_graph_phase10.py
+++ b/tests/python/test_workflow_graph_phase10.py
@@ -661,6 +661,57 @@ def test_paused_workflow_is_not_shown_as_a_crash():
     assert "chờ anh duyệt" in block
 
 
+def test_kanban_marks_a_paused_workflow_as_needing_a_person(tmp_path):
+    """Task chạy workflow mà dừng chờ duyệt KHÔNG được chấm là xong với kết quả rỗng.
+
+    Chạy thật `_execute` với một execute_workflow giả, không quét chuỗi source.
+    """
+    from tasks import TasksDeps, TasksFeature
+
+    async def paused_workflow(brain_root, slug, intent, tools):
+        yield {"type": "start", "workflow": "demo", "steps": 2}
+        yield {"type": "step_done", "i": 0, "output": "đã soạn xong"}
+        yield {"type": "wait_user", "node": "w", "reason": "write_node_needs_confirmation",
+               "prompt": "Gửi email cho khách?"}
+
+    feature = TasksFeature(TasksDeps(
+        brain_root=lambda b: str(tmp_path),
+        atomic_write_text=lambda path, text: None,
+        execute_workflow=paused_workflow,
+        workflows_dir=lambda b: tmp_path,
+        build_system_prompt=lambda b: "",
+        aux_model=lambda: None,
+        safe_tools=[],
+        state_dir=tmp_path,
+    ))
+    result, error, needs_input, _meta = asyncio.run(feature._execute({
+        "route": "wf:demo", "intent": "gửi báo cáo", "brain_root": str(tmp_path),
+    }))
+    assert needs_input is True, "phải chuyển sang trạng thái cần người"
+    assert not error
+    assert "[[NEEDS_INPUT]]" in result and "chờ duyệt" in result
+    assert "Gửi email cho khách?" in result, "phải nói rõ đang chờ duyệt việc gì"
+
+
+def test_kanban_surfaces_an_agent_escalation_too(tmp_path):
+    from tasks import TasksDeps, TasksFeature
+
+    async def escalating(brain_root, slug, intent, tools):
+        yield {"type": "escalation", "reason": "repeated_failure_signature"}
+
+    feature = TasksFeature(TasksDeps(
+        brain_root=lambda b: str(tmp_path),
+        atomic_write_text=lambda path, text: None,
+        execute_workflow=escalating, workflows_dir=lambda b: tmp_path,
+        build_system_prompt=lambda b: "", aux_model=lambda: None,
+        safe_tools=[], state_dir=tmp_path,
+    ))
+    result, _error, needs_input, _meta = asyncio.run(feature._execute({
+        "route": "wf:demo", "intent": "x", "brain_root": str(tmp_path),
+    }))
+    assert needs_input is True and "repeated_failure_signature" in result
+
+
 if __name__ == "__main__":
     import sys
     import pytest

--- a/tests/python/test_workflow_graph_phase10.py
+++ b/tests/python/test_workflow_graph_phase10.py
@@ -597,6 +597,39 @@ def test_each_brain_loads_its_own_nested_workflows(tmp_path, monkeypatch):
     assert a.revision != b.revision, "mỗi brain phải ra đồ thị của chính nó"
 
 
+def test_graph_path_events_carry_the_step_index_studio_needs(tmp_path, monkeypatch):
+    """Studio định vị chỗ đổ chữ bằng `i`. Thiếu nó thì chữ bị vứt lặng lẽ."""
+    import copy
+    import config as cfgmod
+
+    on = copy.deepcopy(cfgmod._DEFAULT)
+    on["context_runtime"]["mode"] = "canary"
+    on["context_runtime"]["workflow_canary"].update(
+        {"allocation_basis_points": 10_000, "allowed_slugs": ["demo"]})
+    main, brain, _ = _brain_with_workflow(tmp_path, monkeypatch, on)
+
+    class StreamingEngine:
+        def __init__(self, *a, **k):
+            self.model = None
+
+        async def query(self, prompt):
+            yield {"type": "text", "content": "từng"}
+            yield {"type": "tool_call", "name": "Read"}
+            yield {"type": "final", "content": "xong"}
+
+    monkeypatch.setattr(main, "claude_engine", lambda **k: StreamingEngine())
+    events = _drain(main.execute_workflow("brain", "demo", input="x", session_id="s"))
+
+    streamed = [x for x in events if x["type"] in
+                ("step_text", "step_tool", "step_start", "step_done")]
+    assert streamed, "phải có event bước"
+    for event in streamed:
+        assert "i" in event, f"{event['type']} thiếu chỉ số bước"
+        assert isinstance(event["i"], int)
+    # Và chỉ số phải trỏ đúng bước, không phải luôn là 0.
+    assert {x["i"] for x in streamed if x["type"] == "step_text"} == {0, 1}
+
+
 if __name__ == "__main__":
     import sys
     import pytest


### PR DESCRIPTION
Phase cuối của kế hoạch 12 phase.

Mặc định repository KHÔNG đổi hành vi: `model_router_canary.allocation_basis_points = 0`, `models = []`. Model anh chọn ở trang Models vẫn là model chạy thật.

## Lọc trước, xếp hạng sau

Luật nặng nhất của spec mục 9.3: *"Không đổi model chỉ để tiết kiệm nếu việc đổi làm mất năng lực cần thiết."*

Router chạy theo thứ tự **cứng**. Ứng viên thiếu năng lực bắt buộc, vượt cửa sổ context, bị chính sách dữ liệu cấm, chậm quá deadline hay đắt quá ngân sách bước đều bị loại **hẳn**. Rẻ hơn chỉ là tiêu chí xếp hạng **giữa những ứng viên đã đủ năng lực**.

Nếu để giá và năng lực cùng vào một công thức tính điểm thì sớm muộn cũng có lúc một model rẻ gấp 60 lần thắng một bước cần tool. Tách hai tầng là cách duy nhất để điều đó không xảy ra được.

**Không đoán năng lực theo tên model.** Rule không khai `supports: ["vision"]` thì model đó không nhận ảnh, kể cả khi tên là `gpt-4o-super-vision-pro` (có test đúng tên này). Rule thiếu giá thật hoặc cửa sổ context bị loại chứ không đoán bù. **Không ai đủ năng lực thì giữ nguyên model anh chọn**, không hạ tiêu chuẩn để có cái mà chạy.

## Năm lỗi tự tìm ra sau khi mở PR

Tất cả cùng một họ: **code đúng, test xanh, nhưng không nối được với thứ nó phục vụ**.

| # | Lỗi | Hệ quả nếu lọt |
|---|---|---|
| 1 | Router không có ai gọi | Phase giao xong nhưng không chạy |
| 2 | Event bước thiếu chỉ số | Studio nuốt toàn bộ chữ đang chạy, người xem thấy bước sáng rồi tắt mà không có nội dung |
| 3 | Studio không biết trạng thái mới | Workflow dừng chờ duyệt trông y hệt bị sập |
| 4 | Kanban không bắt `wait_user` | Task chờ duyệt bị chấm HOÀN THÀNH với kết quả rỗng, việc cần người biến mất |
| 5 | Trace ghi "chờ người" thành `FAILED` | Làm lệch chính các chỉ số dùng làm điều kiện qua phase |

Bổ sung: bộ lọc cửa sổ context từng **vô hiệu** vì chỗ nối không đưa kích thước prompt cho nó - prompt 50 nghìn token vẫn lọt vào model cửa sổ 4 nghìn.

Test đơn vị mù với họ lỗi này vì nó chỉ kiểm phần mình viết. Thứ bắt được chúng là đi **ngược** từ phía tiêu thụ. Đã ghi vào spec kèm một test đối chiếu hai chiều: mọi loại event runtime phát ra đều phải có nhánh xử lý trong `studio.js`.

## Hàng rào an toàn không tự lớn theo hệ thống

Test canh *"cài mặc định không bật đường nào"* viết ở Phase 9 khi mới có 5 đường canary. Phase 10-12 thêm ba đường nữa mà nó không được mở rộng - vẫn xanh hợp lệ, nhưng phần **chạy thật admission** chỉ phủ 5/8. Đã phủ đủ 8 và kiểm chứng bằng cách bật allocation từng đường một.

## Hai chỗ thiết kế sửa giữa chừng

- `priority` từng vừa là thứ tự xếp hạng vừa là cờ an toàn cho bước rủi ro. Test phơi ra ngay: bật `allow_downgrade_on_risk` rồi mà model rẻ vẫn thua vì nó thua ở tầng xếp hạng. Đã tách thành cờ `downgrade` riêng - rào an toàn không nên phụ thuộc vào thứ tự xếp hạng.
- Hai test viết kiểu quét chuỗi source đã được thay bằng test hành vi thật, sau khi một trong hai bắt nhầm khối code khác.

## Chưa làm trong phase này

Reliability live (hiện là số người vận hành khai, chưa tự học từ lỗi quan sát được) và validator bằng model. Cả hai cần dữ liệu production mà hiện chưa có.

## Kiểm thử

17 test mới cho Phase 12; tổng adaptive runtime **190 test**. Mọi hàng rào đều kiểm chứng bằng cách gỡ ra xem test có đỏ không. Toàn bộ test Python chạy theo đúng cách CI chạy: pass, trừ `test_fastyaml.py` đỏ vì container thiếu libyaml (môi trường, không phải code). Test JS pass.