### PR TITLE
Duyệt hành động ghi bằng nút bấm

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1026,8 +1026,14 @@ async def _execute_write_proposal(plan, provider: str, api_key: str, model: str,
     elif status != "prepared":
         text = ("Không ghi được ý định vào sổ nên Javis dừng trước khi gọi tool. "
                 "Chưa có gì thay đổi.")
+    elif not str(registered.get("confirmation_code") or "").strip():
+        # Không có mã thì KHÔNG có cách nào duyệt: nút bấm sẽ chết và câu gõ tay cũng
+        # vô nghĩa. Nói thẳng là hỏng còn hơn bày ra một lời đề xuất không duyệt được.
+        status = "no_confirmation_code"
+        text = ("Javis không tạo được mã duyệt cho hành động ghi này nên đã dừng. "
+                "Chưa có gì thay đổi.")
     else:
-        code = registered.get("confirmation_code", "")
+        code = str(registered.get("confirmation_code")).strip()
         summary = ", ".join(f"{k}={json.dumps(v, ensure_ascii=False)}"
                             for k, v in sorted(args.items()))[:600]
         # Nút bấm, nhưng nhãn PHẢI mang mã của đúng ý định này. Chip gửi đi chính

--- a/server/main.py
+++ b/server/main.py
@@ -1030,12 +1030,26 @@ async def _execute_write_proposal(plan, provider: str, api_key: str, model: str,
         code = registered.get("confirmation_code", "")
         summary = ", ".join(f"{k}={json.dumps(v, ensure_ascii=False)}"
                             for k, v in sorted(args.items()))[:600]
+        # Nút bấm, nhưng nhãn PHẢI mang mã của đúng ý định này. Chip gửi đi chính
+        # nhãn đó như một tin nhắn người dùng, nên mã là thứ giữ lại tính chất cũ:
+        # cú xác nhận gắn với MỘT việc cụ thể, không phải một chữ "xác nhận" trôi
+        # nổi mà gõ nhầm cũng ra. Vẫn nói rõ câu gõ tay cho kênh không có nút.
+        ask = json.dumps({
+            "question": f"Chạy hành động ghi này chứ? ({lease.capability_name})",
+            "header": "Duyệt ghi",
+            "options": [
+                {"label": f"Xác nhận {code}", "desc": "Chạy thật, không hoàn tác được"},
+                {"label": "Huỷ", "desc": "Không chạy, bỏ ý định này"},
+            ],
+        }, ensure_ascii=False)
         text = (
             f"Javis chuẩn bị chạy hành động ghi: {lease.capability_name}.\n"
             f"Tham số: {summary}\n\n"
             f"Việc này thay đổi dữ liệu thật và không tự hoàn tác được, nên Javis "
-            f"CHƯA chạy. Muốn chạy thì anh nhắn lại đúng câu: XAC NHAN {code}\n"
-            f"Không muốn nữa thì nhắn: huỷ"
+            f"CHƯA chạy. Anh bấm nút duyệt bên dưới, hoặc nhắn lại đúng câu: "
+            f"XAC NHAN {code}\n"
+            f"Không muốn nữa thì nhắn: huỷ\n"
+            f"<!-- JAVIS_ASK: {ask} -->"
         )
     if status != "prepared":
         _CONTEXT_RUNTIME.revoke_capability_lease(

--- a/tests/python/test_write_path_phase9.py
+++ b/tests/python/test_write_path_phase9.py
@@ -713,6 +713,52 @@ def test_a_proposal_without_a_code_is_refused_not_shown_as_a_dead_button(tmp_pat
     assert not calls, "và tuyệt đối không chạm tool"
 
 
+def test_the_code_survives_block_stripping_so_a_reload_is_not_a_dead_end(tmp_path, monkeypatch):
+    """Sau F5, dashboard KHÔNG dựng lại nút từ lịch sử.
+
+    Nếu mã chỉ nằm trong khối nút thì tải lại trang là mất đường duyệt. Nên mã phải
+    nằm cả trong phần chữ - đó là lý do vẫn giữ câu gõ tay dù đã có nút.
+    """
+    import json as _json
+    import re as _re
+    import main
+
+    stack = _stack(tmp_path)
+    brain, registry, runtime, trace, store, executor, canary, calls, routes = stack
+    plan = _prepare(stack)
+
+    async def fake_plan(*args):
+        return {"status": "ok", "arguments": {"calendar_id": "primary",
+                "start": "2026-08-05T09:00", "title": "R"},
+                "model": "m", "input": 10, "output": 5}
+
+    class WS:
+        async def send_text(self, raw):
+            pass
+
+    monkeypatch.setattr(main.engine, "single_tool_plan", fake_plan)
+    monkeypatch.setattr(main, "_CAPABILITY_EXECUTOR", executor)
+    monkeypatch.setattr(main, "_CAPABILITY_REGISTRY", registry)
+    monkeypatch.setattr(main, "_CONTEXT_RUNTIME", runtime)
+    monkeypatch.setattr(main, "_WRITE_PATH", canary)
+    monkeypatch.setattr(main, "_brain_root", lambda b: str(brain))
+    monkeypatch.setattr(main.usage_store, "record", lambda *a, **k: None)
+    main._WRITE_PENDING_ARGS.clear()
+
+    text, _model = asyncio.run(main._execute_write_proposal(
+        plan, "groq", "secret", "m", "off", WS(), "session-f5", trace))
+
+    block = _re.search(r"<!--\s*JAVIS_ASK:\s*([\s\S]*?)\s*-->", text)
+    code = _json.loads(block.group(1))["options"][0]["label"].split()[-1]
+
+    # Đúng phép bóc mà bản lưu dùng.
+    stored = _re.sub(r"<!--\s*JAVIS_ASK:[\s\S]*?-->", "", text).strip()
+    assert "JAVIS_ASK" not in stored
+    assert code in stored, "mã phải còn trong phần chữ, không chỉ trong khối nút"
+    # Và gõ lại đúng câu đó vẫn duyệt được.
+    assert canary.pending_for("session-f5", f"XAC NHAN {code}").action == "execute"
+
+
 if __name__ == "__main__":
     import sys
     try:

--- a/tests/python/test_write_path_phase9.py
+++ b/tests/python/test_write_path_phase9.py
@@ -585,6 +585,85 @@ def test_two_turn_flow_through_main_executes_once(tmp_path, monkeypatch):
     assert len(calls) == 1
 
 
+# --------------------------------------------------- duyệt bằng nút bấm
+
+def test_proposal_offers_buttons_whose_label_carries_the_code(tmp_path, monkeypatch):
+    """Nút bấm gửi đi chính NHÃN của nó, nên nhãn phải mang mã của đúng ý định này.
+
+    Nếu nhãn chỉ là "Xác nhận" trơn thì bấm nút và gõ nhầm một chữ là như nhau -
+    mất đúng tính chất an toàn đã chọn từ đầu.
+    """
+    import json as _json
+    import re as _re
+    import main
+
+    stack = _stack(tmp_path)
+    brain, registry, runtime, trace, store, executor, canary, calls, routes = stack
+    plan = _prepare(stack)
+    approved = {"calendar_id": "primary", "start": "2026-08-05T09:00", "title": "Review"}
+
+    async def fake_plan(*args):
+        return {"status": "ok", "arguments": dict(approved), "model": "m",
+                "input": 10, "output": 5}
+
+    class WS:
+        def __init__(self):
+            self.events = []
+
+        async def send_text(self, raw):
+            self.events.append(_json.loads(raw))
+
+    monkeypatch.setattr(main.engine, "single_tool_plan", fake_plan)
+    monkeypatch.setattr(main, "_CAPABILITY_EXECUTOR", executor)
+    monkeypatch.setattr(main, "_CAPABILITY_REGISTRY", registry)
+    monkeypatch.setattr(main, "_CONTEXT_RUNTIME", runtime)
+    monkeypatch.setattr(main, "_WRITE_PATH", canary)
+    monkeypatch.setattr(main, "_brain_root", lambda b: str(brain))
+    monkeypatch.setattr(main.usage_store, "record", lambda *a, **k: None)
+    main._WRITE_PENDING_ARGS.clear()
+
+    ws = WS()
+    text, _model = asyncio.run(main._execute_write_proposal(
+        plan, "groq", "secret", "m", "off", ws, "session-nut", trace))
+
+    block = _re.search(r"<!--\s*JAVIS_ASK:\s*([\s\S]*?)\s*-->", text)
+    assert block, "phải có khối nút bấm"
+    ask = _json.loads(block.group(1))
+    labels = [o["label"] for o in ask["options"]]
+    assert any(l.startswith("Xác nhận ") for l in labels), labels
+    assert "Huỷ" in labels
+
+    confirm_label = next(l for l in labels if l.startswith("Xác nhận "))
+    # Nhãn nút phải nằm vừa giới hạn hiển thị của chip (40 ký tự).
+    assert len(confirm_label) <= 40
+
+    # Bấm nút = gửi đúng nhãn đó đi. Phải kích hoạt đúng ý định đang chờ.
+    assert canary.pending_for("session-nut", confirm_label).action == "execute"
+    # Còn một chữ "xác nhận" trôi nổi thì vẫn không được.
+    assert canary.pending_for("session-nut", "ok xác nhận đi").action != "execute"
+    assert not calls, "vòng đề xuất vẫn không chạm tool"
+
+
+def test_button_block_is_stripped_before_the_turn_is_stored():
+    """Khối nút là thứ để VẼ, không phải thứ để lưu vào corpus tự học."""
+    import inspect
+    import main
+
+    source = inspect.getsource(main._persist_turn)
+    assert "JAVIS_ASK" in source, "vẫn phải bóc khối trước khi lưu"
+
+
+def test_typed_confirmation_still_works_for_channels_without_buttons(tmp_path):
+    """Telegram không có nút; câu gõ tay phải còn nguyên tác dụng."""
+    from write_path_runtime import parse_confirmation
+
+    assert parse_confirmation("XAC NHAN A3F9K2") == ("confirm", "A3F9K2")
+    assert parse_confirmation("Xác nhận A3F9K2") == ("confirm", "A3F9K2")
+    assert parse_confirmation("xac nhan a3f9k2") == ("confirm", "A3F9K2")
+    assert parse_confirmation("đồng ý") == ("", "")
+    assert parse_confirmation("ok") == ("", "")
+
+
 if __name__ == "__main__":
     import sys
     try:

--- a/tests/python/test_write_path_phase9.py
+++ b/tests/python/test_write_path_phase9.py
@@ -664,6 +664,55 @@ def test_typed_confirmation_still_works_for_channels_without_buttons(tmp_path):
     assert parse_confirmation("ok") == ("", "")
 
 
+def test_a_proposal_without_a_code_is_refused_not_shown_as_a_dead_button(tmp_path, monkeypatch):
+    """Không có mã thì không có cách nào duyệt - nút sẽ chết, câu gõ tay cũng vô nghĩa.
+
+    Bày ra lời đề xuất không duyệt được là để người dùng bấm vào hư không.
+    """
+    import json as _json
+    import main
+
+    stack = _stack(tmp_path)
+    brain, registry, runtime, trace, store, executor, canary, calls, routes = stack
+    plan = _prepare(stack)
+
+    async def fake_plan(*args):
+        return {"status": "ok", "arguments": {"calendar_id": "primary",
+                "start": "2026-08-05T09:00", "title": "R"},
+                "model": "m", "input": 10, "output": 5}
+
+    real_register = canary.register_proposal
+
+    def register_without_code(*a, **k):
+        out = dict(real_register(*a, **k))
+        out["confirmation_code"] = ""      # mô phỏng sổ trả về thiếu mã
+        return out
+
+    class WS:
+        def __init__(self):
+            self.events = []
+
+        async def send_text(self, raw):
+            self.events.append(_json.loads(raw))
+
+    monkeypatch.setattr(main.engine, "single_tool_plan", fake_plan)
+    monkeypatch.setattr(main, "_CAPABILITY_EXECUTOR", executor)
+    monkeypatch.setattr(main, "_CAPABILITY_REGISTRY", registry)
+    monkeypatch.setattr(main, "_CONTEXT_RUNTIME", runtime)
+    monkeypatch.setattr(main, "_WRITE_PATH", canary)
+    monkeypatch.setattr(main, "_brain_root", lambda b: str(brain))
+    monkeypatch.setattr(main.usage_store, "record", lambda *a, **k: None)
+    monkeypatch.setattr(canary, "register_proposal", register_without_code)
+    main._WRITE_PENDING_ARGS.clear()
+
+    text, _model = asyncio.run(main._execute_write_proposal(
+        plan, "groq", "secret", "m", "off", WS(), "session-nomã", trace))
+
+    assert "JAVIS_ASK" not in text, "không được bày nút không bấm được"
+    assert "không tạo được mã duyệt" in text
+    assert not calls, "và tuyệt đối không chạm tool"
+
+
 if __name__ == "__main__":
     import sys
     try:


### PR DESCRIPTION
Anh Quy chọn nút bấm thay cho việc gõ lại `XAC NHAN <mã>`.

## Điểm phải giữ khi đổi

Cơ chế nút sẵn có (`JAVIS_ASK`) gửi đi chính **nhãn** của nút như một tin nhắn người dùng bình thường. Nếu nhãn chỉ là `Xác nhận` trơn thì **bấm nút và gõ nhầm một chữ trở thành như nhau** - mất đúng tính chất an toàn đã chọn từ đầu, mà mất một cách kín đáo.

Nên nhãn là `Xác nhận <mã>`. Cú duyệt vẫn gắn với **một việc cụ thể**, chỉ khác là anh không phải gõ nữa. Đổi nhãn thành trơn là test đỏ.

## Ba hoàn cảnh đã kiểm, không chỉ đường đi thuận lợi

| Hoàn cảnh | Hành vi |
|---|---|
| Kênh chữ thuần (Telegram) | Khối tự hạ thành danh sách đánh số, **vẫn còn mã** để gõ lại |
| Mã rỗng do sổ trả thiếu | Từ chối hẳn kèm giải thích, **không bày nút chết** để bấm vào hư không |
| Sau khi F5 | Dashboard không dựng lại nút từ lịch sử, nên mã phải nằm cả trong **phần chữ** - nếu không, tải lại trang là ngõ cụt |

Hoàn cảnh thứ ba giải thích một chỗ trông có vẻ thừa: lời đề xuất vừa có nút, vừa có câu gõ tay. Không phải lặp - đó là đường duyệt duy nhất còn lại sau khi tải lại trang. Nay có test canh: bỏ câu đó đi là đỏ.

## Không thêm cơ chế mới

Dùng khối `JAVIS_ASK` đã chạy sẵn. Khối bị bóc trước khi lưu nên không đẩy rác vào corpus tự học, còn mã vẫn ở lại trong phần chữ.

Câu gõ tay kiểu cũ nguyên tác dụng. `ok`, `đồng ý`, `ừ` vẫn không kích hoạt được gì.

## Phạm vi: một chỗ, không phải ba

Trước em nói có ba chỗ hỏi người dùng. Làm rồi mới thấy chỉ **một** chỗ có nút bấm làm được việc thật:

- **Đường write trong chat (Phase 9)** - đã đổi sang nút. Bấm là chạy thật.
- **Node ghi trong workflow (Phase 10)** - workflow dừng đúng, nhưng đường chạy tiếp sau xác nhận chưa được nối vào endpoint nào (Phase 10 cố ý để ngoài phạm vi). Đặt nút ở đây là đặt một **nút chết**. Giữ nguyên thông báo bằng chữ.
- **Agent chuyển lại cho người (Phase 11)** - là thông tin, không có hành động nào để bấm.

Khi nào nối đường chạy tiếp của workflow thì chỗ thứ hai dùng lại đúng khuôn này.

## Một điểm cosmetic cố ý không sửa

Trên Telegram, câu "Anh bấm nút duyệt bên dưới" hơi lạ vì kênh đó chỉ có danh sách đánh số. Đường write hiện chỉ bật cho `dashboard` nên Telegram không nhận tin này; và câu "hoặc nhắn lại đúng câu..." ngay sau đó vẫn nói đủ cách làm. Ghi lại để khi nào bật Telegram cho write thì chỉnh luôn thể.

## Kiểm thử

6 test mới, mỗi hàng rào kiểm chứng bằng cách gỡ ra xem có đỏ không. Toàn bộ test Python chạy theo đúng cách CI chạy: pass, trừ `test_fastyaml.py` đỏ vì container thiếu libyaml (môi trường, không phải code). Test JS pass.