### PR TITLE
fix: 0.14.5-0.14.7 - mở khoá mức Siêu tiết kiệm, Javis biết mấy giờ, và dọn đường nâng mặc định

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Lịch sử phiên bản Javis OS. Bản mới nhất ở trên cùng. Xem ngay 
 
 Định dạng: mỗi phiên bản là một khối `## [x.y.z] - ngày`, bên dưới nhóm thay đổi theo `### Thêm mới / Sửa lỗi / Cải thiện / Bảo mật`.
 
+## [0.14.6] - 2026-08-03
+Javis biết bây giờ mấy giờ trên mọi đường, thôi bịa lý do khi không biết.
+### Sửa lỗi
+- **Hỏi mấy giờ thì Javis nói "MCP server đang mất kết nối".** Không có server nào mất kết nối cả. Sự thật là lượt đó đi đường tắt của mức Siêu tiết kiệm, mà đường tắt gửi gói tin KHÔNG kèm tool nào - đó chính là chỗ nó tiết kiệm. Model thì không có đồng hồ sẵn trong đầu, nên khi bị hỏi giờ mà không có tool để gọi, nó làm cái tệ nhất: bịa ra một lý do nghe hợp lý.
+
+  Bộ lọc câu hỏi có chặn "bây giờ", "hôm nay" và bắt những câu đó đi đường đầy đủ, nhưng chặn theo từ khoá là trò đuổi bắt: "giờ Việt Nam là mấy giờ" lọt qua ngay. Nay chữa ở gốc - mọi gói tin Javis gửi đi, đường tắt lẫn đường đầy đủ, đều mang sẵn một dòng giờ thật theo múi giờ Việt Nam. Khoảng 30 token mỗi lượt, đổi lấy việc không còn cửa nào để bịa, và bật hay tắt tiết kiệm thì Javis cũng biết giờ y như nhau.
+
+  Múi giờ là UTC+7 cố định chứ không đọc múi giờ của máy chủ, vì VPS gần như luôn chạy giờ UTC.
+### Cải thiện
+- Trang **Tiết kiệm token** đổi tên thành **Tiết kiệm** cho gọn.
+
 ## [0.14.5] - 2026-08-03
 Dọn đường để sau này nâng được mức tiết kiệm mặc định, mà không giẫm lên ai đã tự chọn.
 ### Sửa lỗi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Lịch sử phiên bản Javis OS. Bản mới nhất ở trên cùng. Xem ngay 
 
 Định dạng: mỗi phiên bản là một khối `## [x.y.z] - ngày`, bên dưới nhóm thay đổi theo `### Thêm mới / Sửa lỗi / Cải thiện / Bảo mật`.
 
+## [0.14.5] - 2026-08-03
+Dọn đường để sau này nâng được mức tiết kiệm mặc định, mà không giẫm lên ai đã tự chọn.
+### Sửa lỗi
+- **Đổi mức tiết kiệm mặc định sẽ không bao giờ tới được máy đã cài.** Cái bẫy nằm ở chỗ Javis lưu cấu hình: mỗi lần ghi là ghi lại TOÀN BỘ config đã trộn, nên ngay lần đầu người dùng bấm bất cứ nút nào ở trang Cài đặt, giá trị mặc định của đúng ngày hôm đó bị đóng băng vào settings.json. Lúc đọc thì file lại đè lên mặc định. Hệ quả: về sau nâng mặc định lên mức Tối ưu hay Siêu tiết kiệm thì chỉ máy cài mới tinh mới thấy, còn máy đang chạy thì không, và không có lỗi nào báo ra cả. Đây đúng là con bệnh đã cắn `provider_kinds` hồi 0.12.4, lần này rơi vào thứ quyết định mỗi lượt chat tốn bao nhiêu token.
+
+  Chỗ khó riêng: số 0 nằm trong file có hai nghĩa ngược nhau, "đã cân nhắc và cố ý chọn Tắt" và "chưa ai chọn gì cả". Không phân biệt được thì hoặc là giẫm lên quyết định của người dùng, hoặc là mặc định mới không bao giờ tới nơi. Nay mọi lần tự đổi mức đều để lại chữ ký, và có chữ ký thì bản cập nhật không đụng vào. Máy chưa từng chọn thì đi theo mặc định của bản đang chạy, kể cả máy đã cài từ lâu.
+### Cải thiện
+- **Trang Tiết kiệm nói rõ mức đang chạy là do anh chọn hay chỉ là mặc định.** Hai thứ đó trông y hệt nhau trên màn hình mà ý nghĩa ngược nhau: cái sau sẽ đi lên theo bản cập nhật, cái trước thì không. Chưa chọn bao giờ thì có một dòng nói thẳng điều đó, kèm cách ghim lại là bấm một mức bất kỳ, kể cả bấm đúng mức đang hiện.
+- **Nâng mức mặc định chỉ NÂNG, không bao giờ HẠ.** Máy đang chạy mức cao hơn mặc định, kể cả do sửa tay settings.json, vẫn giữ nguyên. Không có thứ gì người dùng đã bật bị bản cập nhật tắt đi.
+- Bảng "mức nào bật đường nào" gom về một chỗ duy nhất. Trước đó nó nằm ở `main.py`, mà chỗ nâng mặc định lại ở `config.py` và không import được sang - chép ra hai bản thì tới lúc thêm một đường vào mức nào đó, chỗ nâng mặc định vẫn nâng theo bảng cũ, lệch âm thầm.
+### Lưu ý
+- Bản này chưa đổi mặc định của ai, mức xuất xưởng vẫn là Tắt. Nó chỉ dựng sẵn cơ chế để lần nâng sau đi được tới nơi. Một chỗ mơ hồ còn lại, nói ra cho minh bạch: máy nào từng cố ý chọn Tắt TRƯỚC bản này thì không để lại chữ ký nào, nên tới ngày nâng mặc định sẽ được nâng theo. Bấm một mức một lần sau khi cập nhật là ghim vĩnh viễn.
+
 ## [0.14.4] - 2026-08-03
 Gói Claude Code dùng được mức Siêu tiết kiệm. Trước đó nó là bộ não duy nhất bị đứng ngoài.
 ### Thêm mới

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Lịch sử phiên bản Javis OS. Bản mới nhất ở trên cùng. Xem ngay 
 
 Định dạng: mỗi phiên bản là một khối `## [x.y.z] - ngày`, bên dưới nhóm thay đổi theo `### Thêm mới / Sửa lỗi / Cải thiện / Bảo mật`.
 
+## [0.14.7] - 2026-08-03
+Mức Siêu tiết kiệm chưa chạy lần nào trên máy đấu nhiều MCP. Tìm ra và mở khoá.
+### Sửa lỗi
+- **Đường tắt bị chặn ở gần như mọi lượt, càng đấu nhiều nguồn càng chặn chắc.** Chủ repo báo "chưa lần nào chat anh nhìn thấy chữ Tức thì", và soi ra thì đúng như vậy. Cửa nhận lượt xét số ứng viên **dò được bằng chữ**, đếm trước khi chấm điểm và trước khi lọc quyền. Trên máy đấu vài trăm tool MCP (Gmail, Drive, Lịch, quảng cáo...), gần như câu tiếng Việt nào cũng dò trúng vài tool qua một từ chung, nên điều kiện đó đúng với mọi lượt và đường tắt không bao giờ chạy.
+
+  Nghĩa là mức Siêu tiết kiệm càng đấu nhiều nguồn càng không tiết kiệm được, ngược hẳn thứ nó hứa. Trên máy dev thì không lộ, vì kho tool ở đó gần như rỗng và mọi test đều xanh.
+
+  Nay xét **điểm khớp cao nhất** sau khi đã chấm. Có cái suýt trúng thì vẫn nhường đường thường cho chắc, còn dò trúng một từ vu vơ thì không phải lý do để bỏ đường tắt. Ngưỡng nằm ở `context_runtime.canary.min_resolver_score` (mặc định 0.45) để vặn được khi cần.
+- **Nhiều nhánh trả lời không gắn nhãn chế độ, nên có lượt không hiện gì dưới câu trả lời.** Dòng "chế độ + token" do gói tin trả lời mang theo, mà chỉ ba nhánh gắn nó. Nhánh nhắc hẹn, nhánh tra cứu, nhánh thực thi, nhánh từ chối vì vượt hạn mức đều gửi câu trả lời trần. Nay mọi gói trả lời đều mang nhãn, và có test soát toàn bộ mã nguồn để không nhánh nào mới thêm bị sót nữa.
+### Thêm mới
+- **Trang Tiết kiệm nói thẳng vì sao lượt chat chưa đi được đường tắt**, gộp theo lý do và xếp theo số lần. Bảng "Lượt gần nhất" đã ghi lý do từng dòng, nhưng một lý do chiếm 18 trên 20 lượt là một cái hỏng còn xuất hiện 2 lần thì bình thường, mà nhìn từng dòng không phân biệt nổi hai ca đó. Chính vì thiếu con số này mà lỗi ở trên phải chờ chủ repo nói bằng lời mới lộ ra.
+
 ## [0.14.6] - 2026-08-03
 Javis biết bây giờ mấy giờ trên mọi đường, thôi bịa lý do khi không biết.
 ### Sửa lỗi

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1810,8 +1810,8 @@ async function _usageSavingRow() {
   else if (d.preset === "off") phu = "chưa bật tiết kiệm";
   else if (uoc.phan_tram) phu = `giảm ~${uoc.phan_tram}% (ước lượng)`;
   else phu = "chưa đo được";
-  const html = `<div style="display:flex;justify-content:space-between;gap:6px;font-size:11px;padding:3px 0 0;margin-top:3px;border-top:1px solid var(--hairline);cursor:pointer" data-usage-goto="runtime" title="Mở trang Tiết kiệm token">`
-    + `<span style="color:var(--text2)">Tiết kiệm token: <b>${escapeHtml(ten)}</b></span>`
+  const html = `<div style="display:flex;justify-content:space-between;gap:6px;font-size:11px;padding:3px 0 0;margin-top:3px;border-top:1px solid var(--hairline);cursor:pointer" data-usage-goto="runtime" title="Mở trang Tiết kiệm">`
+    + `<span style="color:var(--text2)">Tiết kiệm: <b>${escapeHtml(ten)}</b></span>`
     + `<span style="color:#7aa2ff;white-space:nowrap">${escapeHtml(phu)}</span></div>`;
   _savingCache = { at: now, html };
   return html;

--- a/dashboard/console.css
+++ b/dashboard/console.css
@@ -801,6 +801,9 @@ body.has-rail .hud { margin-left: var(--rail-w); width: calc(100% - var(--rail-w
 .rt-preset-na { display: inline-block; margin-top: 8px; margin-right: 6px; font-size: 11px;
   color: var(--warn-ink); border: 1px solid var(--warn-line); border-radius: 999px;
   padding: 1px 8px; }
+/* "Mức này chỉ là mặc định, anh chưa chọn." Đậm hơn rt-note thường vì nó nói một điều người
+   dùng không đoán được: cái đang hiện có thể tự đổi sau bản cập nhật. */
+.rt-chuachon { opacity: .85; border-left: 2px solid var(--line); padding-left: 10px; }
 .rt-adv { border: 1px solid var(--line); border-radius: 12px; padding: 10px 14px; }
 .rt-adv summary { cursor: pointer; font-size: 13px; font-weight: 600; list-style: none; }
 .rt-adv summary::-webkit-details-marker { display: none; }

--- a/dashboard/console.css
+++ b/dashboard/console.css
@@ -801,6 +801,7 @@ body.has-rail .hud { margin-left: var(--rail-w); width: calc(100% - var(--rail-w
 .rt-preset-na { display: inline-block; margin-top: 8px; margin-right: 6px; font-size: 11px;
   color: var(--warn-ink); border: 1px solid var(--warn-line); border-radius: 999px;
   padding: 1px 8px; }
+.rt-visao-list { margin: 6px 0 0; padding-left: 18px; font-size: 13px; line-height: 1.7; }
 /* "Mức này chỉ là mặc định, anh chưa chọn." Đậm hơn rt-note thường vì nó nói một điều người
    dùng không đoán được: cái đang hiện có thể tự đổi sau bản cập nhật. */
 .rt-chuachon { opacity: .85; border-left: 2px solid var(--line); padding-left: 10px; }

--- a/dashboard/console.js
+++ b/dashboard/console.js
@@ -87,7 +87,7 @@
     { id: "logs",        icon: ICON.logs,        label: "Cập nhật" },
     { id: "account",     icon: ICON.account,     label: "Tài khoản" },
     { id: "usage",       icon: ICON.usage,       label: "Mức dùng" },
-    { id: "runtime",     icon: ICON.runtime,     label: "Tiết kiệm token" },
+    { id: "runtime",     icon: ICON.runtime,     label: "Tiết kiệm" },
   ];
 
   // ---- Gom rail thành nhóm theo chức năng (dễ tìm hơn danh sách phẳng 18 mục) ----
@@ -142,7 +142,7 @@
     logs:        { icon: VIEW_ICON.logs, label: "Nhật ký cập nhật", sub: "Phiên bản & tính năng mới" },
     account:     { icon: VIEW_ICON.account, label: "Tài khoản", sub: "Đăng nhập & workspace" },
     usage:       { icon: VIEW_ICON.usage, label: "Mức dùng", sub: "Token & chi phí theo ngày, theo nhà cung cấp" },
-    runtime:     { icon: VIEW_ICON.runtime, label: "Tiết kiệm token", sub: "Xem Javis đang tốn bao nhiêu token mỗi lượt, và chọn mức tiết kiệm" },
+    runtime:     { icon: VIEW_ICON.runtime, label: "Tiết kiệm", sub: "Xem Javis đang tốn bao nhiêu token mỗi lượt, và chọn mức tiết kiệm" },
   };
 
   // 4 trang tách từ Studio cũ - render container rồi gọi loader trong studio.js (window.JavisStudio).

--- a/dashboard/console.js
+++ b/dashboard/console.js
@@ -415,6 +415,10 @@
         </div>
         ${d.preset === "custom" ? `<div class="dim rt-note">Cấu hình hiện tại không khớp mức
           nào (đã chỉnh tay ở phần Nâng cao). Bấm một mức để về lại chuẩn.</div>` : ""}
+        ${d.preset_nguon === "user" ? "" : `<div class="dim rt-note rt-chuachon">Mức đang chạy
+          là <b>mặc định của bản này</b>, anh chưa tự chọn bao giờ. Bản cập nhật sau có thể
+          nâng nó lên. Bấm một mức bất kỳ là Javis ghim lại, từ đó không bản nào đổi nữa
+          (kể cả bấm đúng mức đang chạy).</div>`}
         <div class="dim rt-note">Đổi xong có hiệu lực ngay, không cần khởi động lại. Thấy Javis
         trả lời tệ đi thì bấm <b>Tắt</b> là quay lại như cũ lập tức.
         ${uoc.la_uoc_luong ? ` Con số phần trăm là <b>ước lượng</b> đo trên chính bộ não và bộ

--- a/dashboard/console.js
+++ b/dashboard/console.js
@@ -442,6 +442,8 @@
         lượt chạy ở cả chế độ Đầy đủ lẫn chế độ Tối ưu trong 24 giờ qua. Bật một mức rồi chat
         vài câu là bảng đo sẽ hiện ra ở đây.</div>`}
 
+      ${_viSao(d.vi_sao)}
+
       <div class="rt-banner ${anyOn ? "rt-on" : "rt-off"}">
         ${ic(anyOn ? "triangle-alert" : "check", { cls: anyOn ? "ic-warn" : "ic-ok" })}
         <div>
@@ -682,6 +684,27 @@
   };
   function _lyDo(ma) {
     return LY_DO_LABEL[ma] || String(ma || "");
+  }
+  // Lý do LẶP LẠI khiến lượt không đi được đường tắt. Bảng "Lượt gần nhất" đã ghi lý do từng
+  // dòng, nhưng một lý do chiếm 18 trên 20 lượt là một cái hỏng, còn xuất hiện 2 lần thì
+  // bình thường - nhìn từng dòng không phân biệt nổi hai ca đó. Chủ repo đã phải nói bằng
+  // lời "chưa lần nào thấy chữ Tức thì" thay vì chỉ vào một con số ở đây.
+  function _viSao(vs) {
+    const top = (vs && vs.top) || [];
+    const tong = Number(vs && vs.tong) || 0;
+    if (!tong || !top.length) return "";
+    const dong = top.map((x) => {
+      const pct = Math.round((Number(x.so_lan) || 0) * 100 / tong);
+      return `<li><b>${pct}%</b> ${esc(_lyDo(x.ma))}
+        <span class="dim">(${Number(x.so_lan) || 0}/${tong} lượt)</span></li>`;
+    }).join("");
+    return `<div class="rt-sec rt-visao">
+      <h3>Vì sao lượt chat chưa đi đường tắt</h3>
+      <ul class="rt-visao-list">${dong}</ul>
+      <div class="dim rt-note">Đường tắt (nhãn <b>Tức thì</b>) chỉ nhận câu chắc chắn không
+      cần tra cứu gì. Lý do nào chiếm gần hết số lượt thì đó là chỗ đang chặn, không phải
+      chuyện ngẫu nhiên.</div>
+    </div>`;
   }
   function _tenDuong(paths) {
     const out = {};

--- a/server/config.py
+++ b/server/config.py
@@ -144,6 +144,12 @@ _DEFAULT = {
             "registry_max_age_seconds": 900,
             "estimator_safety_factor": 1.35,
             "max_objective_chars": 12000,
+            # Điểm khớp tối thiểu để coi là "câu này có thể cần tool" và nhường đường thường.
+            # Xét ĐIỂM chứ không xét số ứng viên dò trúng chữ: máy đấu vài trăm tool MCP thì
+            # câu nào cũng dò trúng vài cái qua một từ chung, và đường tắt sẽ không bao giờ
+            # chạy. Hạ số này = đi tắt nhiều hơn nhưng dễ trả lời hụt; nâng lên = an toàn hơn
+            # nhưng tiết kiệm ít đi. Cùng thang điểm với readonly_canary.min_resolver_score.
+            "min_resolver_score": 0.45,
             # Không hardcode quota thương mại. Operator thêm rule versioned theo tài khoản thật:
             # {"id":"groq-free", "provider":"groq", "model_pattern":"llama-*",
             #  "rolling_tpm":12000, "context_window":131072,

--- a/server/config.py
+++ b/server/config.py
@@ -125,6 +125,11 @@ _DEFAULT = {
         "retention_days": 14,
         "export_enabled": False,
         "estimate_chars_per_token": 3.0,   # heuristic observe-only, reconcile bằng usage thật
+        # CHỮ KÝ lựa chọn mức tiết kiệm của người dùng. Rỗng = chưa ai chọn, mức đang chạy
+        # chỉ là mặc định của bản đã cài. Xem `_ap_muc_mac_dinh` để biết vì sao thiếu trường
+        # này thì mọi lần đổi mặc định về sau đều không tới được máy đã cài.
+        # source: "user" (người dùng tự bấm/tự đổi) | "" (chưa chọn bao giờ).
+        "preset_choice": {"level": "", "source": "", "at": ""},
         "canary": {
             "policy_version": "fast-path-canary-v1",
             "allocation_basis_points": 0,  # 100 = 1%; hash ổn định theo session
@@ -412,6 +417,91 @@ def _deep_merge(base: dict, patch: dict) -> dict:
     return base
 
 
+RUNTIME_MODES = ("off", "observe", "shadow", "canary", "on")
+
+# MỖI MỨC TIẾT KIỆM BẬT NHỮNG ĐƯỜNG NÀO. Bảng này là nguồn sự thật; `main.RUNTIME_PRESETS`
+# chỉ khoác thêm nhãn và mô tả cho người đọc. Để ở config vì `_ap_muc_mac_dinh` bên dưới cần
+# nó, mà config thì không import được main (vòng lặp import).
+PRESET_DUONG = {
+    "off": {"mode": "shadow", "duong": {}},
+    "saving": {"mode": "canary", "duong": {
+        "conversation_state_canary": 10000,
+        "memory_canary": 10000,
+        "lazy_skill_canary": 10000,
+    }},
+    "max": {"mode": "canary", "duong": {
+        "conversation_state_canary": 10000,
+        "memory_canary": 10000,
+        "lazy_skill_canary": 10000,
+        "canary": 10000,
+    }},
+}
+
+# MỨC XUẤT XƯỞNG CỦA BẢN NÀY. Đổi đúng dòng này là đổi mặc định cho MỌI máy chưa từng tự
+# chọn mức, kể cả máy đã cài từ lâu. Đừng sửa `_DEFAULT` ở trên để đổi mặc định: xem
+# `_ap_muc_mac_dinh` để biết vì sao sửa ở đó không tới được máy nào.
+PRESET_MAC_DINH = "off"
+
+
+def _ap_muc_mac_dinh(cfg: dict) -> bool:
+    """Nâng mức tiết kiệm lên ÍT NHẤT mức xuất xưởng, nếu người dùng CHƯA TỪNG tự chọn mức.
+
+    Vì sao phải có, và vì sao sửa `_DEFAULT` là không đủ. `write_settings` ghi lại TOÀN BỘ
+    config đã trộn, nên ngay lần đầu người dùng bấm bất cứ nút nào ở trang Cài đặt, giá trị
+    mặc định của NGÀY HÔM ĐÓ bị đóng băng vào settings.json. `read_settings` lại trộn file ĐÈ
+    LÊN mặc định. Hệ quả: về sau ta có nâng mặc định lên mức Tối ưu hay Siêu tiết kiệm thì
+    máy đã cài rồi KHÔNG BAO GIỜ thấy - mặc định mới chỉ tới được máy cài mới tinh. Đúng con
+    bệnh đã cắn `provider_kinds` hồi 0.12.4 (xem `_no_rong_pham_vi_bo_nao`), lần này rơi vào
+    thứ quyết định mỗi lượt chat tốn bao nhiêu token.
+
+    Cái khó riêng của mức tiết kiệm: số 0 nằm trong file có HAI nghĩa hoàn toàn khác nhau -
+    "người dùng đã cân nhắc và cố ý chọn Tắt", hoặc "chưa ai chọn gì, đây là mặc định cũ
+    đóng băng lại". Không phân biệt được hai cái đó thì hoặc là ta giẫm lên quyết định của
+    người dùng, hoặc là mặc định mới không bao giờ tới nơi. Nên từ bản này, mọi lần người
+    dùng tự đổi mức đều để lại chữ ký `preset_choice.source == "user"`, và có chữ ký thì hàm
+    này không đụng vào gì hết.
+
+    CHỈ NÂNG, KHÔNG BAO GIỜ HẠ. Máy đang chạy mức cao hơn mặc định (kể cả do sửa tay
+    settings.json, thứ không để lại chữ ký nào) vẫn giữ nguyên mức của nó. Nhờ vậy trường
+    hợp mơ hồ duy nhất còn lại là máy cũ từng cố ý chọn Tắt TRƯỚC khi có chữ ký: máy đó sẽ
+    được nâng theo mặc định mới. Đổi lại, không có gì người dùng đã bật bị tắt đi, và bấm
+    "Tắt" một lần sau khi cập nhật là ghim vĩnh viễn.
+
+    Trả về True nếu có sửa gì, để chỗ gọi biết mà ghi file lại nếu muốn.
+    """
+    rt = cfg.get("context_runtime")
+    if not isinstance(rt, dict):
+        return False
+    chon = rt.get("preset_choice")
+    if isinstance(chon, dict) and str(chon.get("source") or "") == "user":
+        return False
+    muc = PRESET_DUONG.get(PRESET_MAC_DINH) or {}
+    doi = False
+    for ten, bp in (muc.get("duong") or {}).items():
+        entry = rt.get(ten)
+        if not isinstance(entry, dict):
+            continue
+        if int(entry.get("allocation_basis_points") or 0) < int(bp):
+            entry["allocation_basis_points"] = int(bp)
+            doi = True
+    # `mode` là công tắc TRÙM: nâng allocation mà quên nâng mode là bật đúng cái kiểu hỏng
+    # "knob xoay được mà đèn không sáng". Các phase khác (readonly/orchestrator/write) không
+    # bị mode này bật lây vì allowlist capability của chúng mặc định rỗng, và riêng write
+    # còn đòi người dùng gõ lại mã xác nhận.
+    #
+    # Mức xuất xưởng KHÔNG bật đường nào (hôm nay là mức Tắt) thì đừng đụng vào mode: chẳng
+    # có gì để bật, mà mode lại là công tắc dùng chung với các phase khác. Đi sửa một thứ
+    # không cần sửa là cách rẻ nhất để tạo ra một lỗi không ai ngờ tới.
+    can = str(muc.get("mode") or "")
+    if muc.get("duong") and can in RUNTIME_MODES:
+        dang = str(rt.get("mode") or "")
+        i_dang = RUNTIME_MODES.index(dang) if dang in RUNTIME_MODES else -1
+        if i_dang < RUNTIME_MODES.index(can):
+            rt["mode"] = can
+            doi = True
+    return doi
+
+
 def _no_rong_pham_vi_bo_nao(cfg: dict) -> bool:
     """Nới `provider_kinds` của các mảng tiết kiệm về ÍT NHẤT bằng mặc định hiện tại.
 
@@ -472,6 +562,7 @@ def read_settings():
     except Exception:
         pass
     _no_rong_pham_vi_bo_nao(cfg)
+    _ap_muc_mac_dinh(cfg)
     try:
         import secrets_store   # lazy: secrets_store import config → tránh vòng lặp import
         _transform_secret_fields(cfg, secrets_store.decrypt)

--- a/server/context_compiler.py
+++ b/server/context_compiler.py
@@ -12,6 +12,7 @@ import re
 import threading
 import time
 from dataclasses import dataclass, field, replace
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Optional, Protocol
 
 from capability_registry import CapabilityRegistry, get_registry
@@ -20,6 +21,45 @@ from capability_registry import CapabilityRegistry, get_registry
 COMPILER_POLICY_VERSION = "adaptive-compiler-shadow-v1"
 CORE_CONTRACT_VERSION = "javis-core-contract-v1"
 TOKENIZER_POLICY_VERSION = "tokenizer-observe-v1"
+THOI_GIAN_POLICY_VERSION = "dong-ho-vn-v1"
+
+# Việt Nam không có giờ mùa hè nên UTC+7 là hằng số - không phụ thuộc tzdata của máy chủ.
+_TZ_VN = timezone(timedelta(hours=7))
+_THU_VN = ["Thứ Hai", "Thứ Ba", "Thứ Tư", "Thứ Năm", "Thứ Sáu", "Thứ Bảy", "Chủ Nhật"]
+
+
+# Ghim đồng hồ (test đặt một hàm trả datetime cố định). Capsule hash băm trọn phần đã dựng,
+# nên từ lúc có dòng giờ thì THỜI ĐIỂM cũng là một đầu vào của hash. Không ghim được thì hai
+# lần biên soạn rơi hai bên mốc phút sẽ ra hai hash khác nhau, và bất biến "cùng đầu vào thì
+# cùng capsule" thành ra thỉnh thoảng đỏ - loại test đỏ tệ nhất vì chạy lại là xanh.
+_DONG_HO_NOW = None
+
+
+def _bay_gio():
+    return _DONG_HO_NOW() if _DONG_HO_NOW else datetime.now(_TZ_VN)
+
+
+def dong_ho(now=None) -> str:
+    """Một dòng "bây giờ là mấy giờ" để nhét vào MỌI prompt Javis gửi đi.
+
+    Vì sao phải có. Model không có đồng hồ; Javis vốn để nó tự gọi tool `javis_now`. Nhưng
+    đường tắt của mức Siêu tiết kiệm gửi capsule KHÔNG KÈM TOOL NÀO - đó chính là chỗ nó
+    tiết kiệm. Nên hỏi "mấy giờ rồi" trên đường tắt là hỏi một thứ model không có cách nào
+    biết, và nó làm cái tệ nhất: bịa ra lý do. Chủ repo chụp lại đúng cảnh đó, Javis nói
+    "MCP server của Javis hiện đang mất kết nối" trong khi chẳng có server nào mất kết nối
+    cả - chỉ là lượt đó không được phát tool.
+
+    Bộ lọc câu hỏi có chặn "bây giờ", "hôm nay"... nhưng chặn theo từ khoá là trò đuổi bắt:
+    "giờ Việt Nam là mấy giờ" lọt ngay. Sửa ở gốc thì rẻ hơn nhiều - 30 token mỗi lượt đổi
+    lấy việc mọi đường đều biết giờ, không cần tool, không còn cửa nào để bịa.
+
+    Không lo hỏng prompt cache: system prompt của Javis vốn đã đổi mỗi lượt (khối MỨC DÙNG
+    HÔM NAY đếm token theo thời gian thật), nên dòng này không làm mất thêm lần cache nào.
+    """
+    n = now or _bay_gio()
+    return (f"Bây giờ là {n:%H:%M} {_THU_VN[n.weekday()]} ngày {n:%d/%m/%Y}, "
+            "giờ Việt Nam (UTC+7). Đây là giờ THẬT tại thời điểm câu hỏi này được gửi: cứ "
+            "dùng thẳng khi cần biết hôm nay/bây giờ, không phải đoán và không cần gọi tool.")
 
 
 CORE_CONTRACT = """# Javis Core Contract
@@ -390,11 +430,17 @@ class ContextCompiler:
                 "Planner contract: đây là vòng lập arguments. Phải gọi đúng một function được cung cấp, "
                 "không trả prose, không gọi nhiều function và không tự thêm capability."
             )
+        # Đồng hồ đi cùng capsule và là món BẮT BUỘC: đường tắt không phát tool nào, nên
+        # thiếu dòng này là model không có cách nào biết bây giờ mấy giờ.
+        time_text = dong_ho()
         base_system = (CORE_CONTRACT.rstrip() + "\n" + identity_text + "\n" + channel_text +
-                  "\n" + output_text + ("\n" + planner_text if planner_text else ""))
+                  "\n" + time_text + "\n" + output_text +
+                  ("\n" + planner_text if planner_text else ""))
         required_items = [
             ContextItem("core", "core_contract", CORE_CONTRACT, CORE_CONTRACT_VERSION,
                         tokenizer.count_text(CORE_CONTRACT), 1, 1, 1, 1, True, "system"),
+            ContextItem("time", "wall_clock", time_text, THOI_GIAN_POLICY_VERSION,
+                        tokenizer.count_text(time_text), 1, 1, 1, 1, True, "gateway"),
             ContextItem("channel", "channel_context", channel_text, f"channel:{request.channel}",
                         tokenizer.count_text(channel_text), 1, 1, 1, 1, True, "gateway"),
             ContextItem("identity", "provider_identity", identity_text,

--- a/server/fast_path_runtime.py
+++ b/server/fast_path_runtime.py
@@ -139,6 +139,7 @@ class CanaryPolicy:
     registry_max_age_seconds: int
     estimator_safety_factor: float
     max_objective_chars: int
+    min_resolver_score: float
     rules: tuple[QuotaRule, ...]
     version: str
 
@@ -185,6 +186,7 @@ class CanaryPolicy:
             registry_max_age_seconds=max(1, int(raw.get("registry_max_age_seconds") or 900)),
             estimator_safety_factor=max(1.0, min(float(raw.get("estimator_safety_factor") or 1.35), 3.0)),
             max_objective_chars=max(100, int(raw.get("max_objective_chars") or 12_000)),
+            min_resolver_score=max(0.0, min(float(raw.get("min_resolver_score") or 0.45), 1.0)),
             rules=tuple(rules), version=str(raw.get("policy_version") or CANARY_POLICY_VERSION),
         )
 
@@ -307,18 +309,42 @@ class FastPathCanary:
             objective, brain,
             capability_resolver.ActorPolicy(mode="full", channel=channel),
         )
+        # Điểm CAO NHẤT sau khi chấm và lọc, không phải số lần dò trúng chữ. Xem lý do ngay
+        # dưới - đây là chỗ mức Siêu tiết kiệm chết lặng suốt mấy bản liền.
+        _ranked = resolution.get("ranked") or []
+        diem_cao = 0.0
+        try:
+            diem_cao = max(float(x.get("score") or 0.0) for x in _ranked) if _ranked else 0.0
+        except (TypeError, ValueError):
+            diem_cao = 0.0
         self.runtime.record_runtime_event(trace, "resolver.canary", {
             "policy_version": resolution.get("policy_version") or "",
             "registry_revision": resolution.get("registry_revision") or "",
             "candidate_count": resolution.get("candidate_count", 0),
             "selected_count": resolution.get("selected_count", 0),
+            "top_score": round(diem_cao, 6),
+            "min_resolver_score": policy.min_resolver_score,
             "miss_class": resolution.get("miss_class") or "",
             "intent_class": intent.intent_class,
             "intent_confidence": intent.confidence,
         })
         if int(resolution.get("selected_count") or 0) > 0:
             return self._legacy(trace, policy, bucket, "capability_selected")
-        if int(resolution.get("candidate_count") or 0) > 0 or resolution.get("filtered"):
+        # VÌ SAO KHÔNG CÒN XÉT `candidate_count`. Nó là số ứng viên dò được bằng CHỮ, tính
+        # trước khi chấm điểm và trước khi lọc quyền. Trên máy có vài trăm tool MCP (Gmail,
+        # Drive, Lịch, quảng cáo...), gần như câu tiếng Việt nào cũng dò trúng ít nhất một
+        # tool qua một từ chung, nên `candidate_count > 0` đúng với MỌI lượt. Kết quả là mức
+        # Siêu tiết kiệm càng đấu nhiều nguồn càng không bao giờ chạy - ngược hẳn với thứ nó
+        # hứa. Chủ repo báo đúng triệu chứng đó: chưa lần nào thấy chữ "Tức thì".
+        #
+        # Trên máy dev thì không lộ, vì kho tool ở đó gần như rỗng và mọi test đều xanh.
+        #
+        # Nay xét ĐIỂM cao nhất sau khi chấm. Resolver đã tự nói "không chọn cái nào"
+        # (selected_count = 0) ở trên; điểm ở đây trả lời tiếp câu "có cái nào SUÝT trúng
+        # không". Suýt trúng thì nhường đường thường cho chắc, còn dò trúng một từ vu vơ thì
+        # không phải lý do để bỏ đường tắt. `filtered` cũng thôi được xét: capability đã bị
+        # chặn quyền thì đi đường thường cũng không gọi được, chặn đường tắt chẳng cứu ai.
+        if diem_cao >= policy.min_resolver_score:
             return self._legacy(trace, policy, bucket, "capability_ambiguous")
 
         compile_resolution = dict(resolution)

--- a/server/main.py
+++ b/server/main.py
@@ -7676,6 +7676,12 @@ async def runtime_diagnostics(hours: float = Query(24.0), limit: int = Query(200
             "preset": current_preset(settings),
             "presets": [{"id": k, **{x: v[x] for x in ("nhan", "mo_ta")}}
                         for k, v in RUNTIME_PRESETS.items()],
+            # Mức đang chạy là do NGƯỜI DÙNG chọn, hay chỉ là mặc định của bản đã cài? Hai
+            # thứ đó trông y hệt nhau trên màn hình mà ý nghĩa ngược nhau: cái sau sẽ đi lên
+            # theo bản cập nhật, cái trước thì không. Nói ra để người dùng biết mình đang ở
+            # đâu, và biết rằng bấm một mức là ghim lại.
+            "preset_nguon": str((settings.get("preset_choice") or {}).get("source") or ""),
+            "preset_mac_dinh": cfgmod.PRESET_MAC_DINH,
             # Bộ não đang chạy có ăn được phần tiết kiệm này không. Câu hỏi đầu tiên của
             # người dùng khi mở trang, mà trước đây trang không trả lời được: bảng canary
             # chỉ hiện allocation, còn việc engine của họ có nằm trong provider_kinds hay
@@ -8090,7 +8096,7 @@ def canary_set_decision(path: str, allocation_basis_points, entry: dict, allow_i
     return 0, {"ok": True, "allocation_basis_points": bp}
 
 
-_RUNTIME_MODES = ("off", "observe", "shadow", "canary", "on")
+_RUNTIME_MODES = cfgmod.RUNTIME_MODES
 
 # Đường canary nào ĐỌC hạn mức ở chỗ nào. Mặc định là đọc của chính mình; ba đường Phase 8 thì
 # không có `quota_profiles` riêng mà đọc ké `context_sources` (xem AdaptiveContextCanary._quota).
@@ -8112,41 +8118,48 @@ QUOTA_OWNER_OF = {
 # Chỉ đưa vào đây những đường CHẠY ĐƯỢC với cấu hình mặc định. readonly_canary,
 # orchestrator_canary, write_canary... đều đòi allowlist capability mà mặc định rỗng, nên
 # bật chúng chỉ tạo cảm giác đã bật trong khi mọi lượt vẫn rơi về đường cũ.
+#
+# `mode` và `duong` KHÔNG gõ ở đây mà lấy từ `cfgmod.PRESET_DUONG`. Vì sao: `_ap_muc_mac_dinh`
+# bên config phải biết mức xuất xưởng bật những đường nào, mà config không import được main.
+# Chép bảng ra hai chỗ thì tới lúc thêm một đường vào mức nào đó, chỗ nâng mặc định vẫn nâng
+# theo bảng cũ - lệch âm thầm, đúng kiểu lỗi không ai phát hiện cho tới khi hoá đơn token nói.
+def _muc(key: str, nhan: str, mo_ta: str) -> dict:
+    p = cfgmod.PRESET_DUONG[key]
+    return {"nhan": nhan, "mo_ta": mo_ta, "mode": p["mode"], "duong": dict(p["duong"])}
+
+
 RUNTIME_PRESETS = {
-    "off": {
-        "nhan": "Tắt",
-        # Nhắc tên "Đầy đủ" ngay trong mô tả để nối với nhãn chế độ hiện dưới mỗi câu trả lời
-        # và trong bảng đo. Nút thì tên "Tắt" (tắt phần tiết kiệm), còn thứ đang chạy khi tắt
-        # thì tên "Đầy đủ" - không buộc hai tên đó lại là người dùng thấy hai thứ khác nhau.
-        "mo_ta": ("Chế độ Đầy đủ: gửi mọi thứ cho model mỗi lượt. "
-                  "An toàn nhất, tốn token nhất."),
-        "mode": "shadow",
-        "duong": {},
-    },
-    "saving": {
-        "nhan": "Tối ưu",
-        "mo_ta": ("Chỉ gửi phần liên quan tới câu hỏi: nhớ có chọn lọc, skill nạp khi cần. "
-                  "Giảm mạnh token mỗi lượt, hợp với model bị siết hạn mức."),
-        "mode": "canary",
-        "duong": {
-            "conversation_state_canary": 10000,
-            "memory_canary": 10000,
-            "lazy_skill_canary": 10000,
-        },
-    },
-    "max": {
-        "nhan": "Siêu tiết kiệm",
-        "mo_ta": ("Như mức Tiết kiệm, cộng thêm đường tắt cho câu hỏi đơn giản không cần "
-                  "tra cứu gì. Nhanh và rẻ nhất, nhưng mới nhất nên ít được thử nhất."),
-        "mode": "canary",
-        "duong": {
-            "conversation_state_canary": 10000,
-            "memory_canary": 10000,
-            "lazy_skill_canary": 10000,
-            "canary": 10000,
-        },
-    },
+    # Nhắc tên "Đầy đủ" ngay trong mô tả để nối với nhãn chế độ hiện dưới mỗi câu trả lời và
+    # trong bảng đo. Nút thì tên "Tắt" (tắt phần tiết kiệm), còn thứ đang chạy khi tắt thì tên
+    # "Đầy đủ" - không buộc hai tên đó lại là người dùng thấy hai thứ khác nhau.
+    "off": _muc("off", "Tắt",
+                "Chế độ Đầy đủ: gửi mọi thứ cho model mỗi lượt. "
+                "An toàn nhất, tốn token nhất."),
+    "saving": _muc("saving", "Tối ưu",
+                   "Chỉ gửi phần liên quan tới câu hỏi: nhớ có chọn lọc, skill nạp khi cần. "
+                   "Giảm mạnh token mỗi lượt, hợp với model bị siết hạn mức."),
+    "max": _muc("max", "Siêu tiết kiệm",
+                "Như mức Tiết kiệm, cộng thêm đường tắt cho câu hỏi đơn giản không cần "
+                "tra cứu gì. Nhanh và rẻ nhất, nhưng mới nhất nên ít được thử nhất."),
 }
+
+
+def _ky_ten_muc(runtime_cfg: dict, level: str) -> dict:
+    """Đóng dấu "chính người dùng đã chọn mức này" vào config.
+
+    Đây là thứ duy nhất phân biệt được "cố ý chọn Tắt" với "chưa ai chọn gì, mặc định cũ
+    đóng băng lại trong settings.json". Thiếu nó thì mọi lần nâng mặc định về sau đều phải
+    chọn giữa hai cái sai: giẫm lên quyết định của người dùng, hoặc để mặc định mới không bao
+    giờ tới được máy đã cài. Xem `config._ap_muc_mac_dinh`.
+
+    Gọi từ MỌI endpoint đổi mức tiết kiệm, kể cả đổi tay từng đường: người vào tận phần Nâng
+    cao chỉnh allocation rõ ràng là người có ý kiến riêng, đừng nâng của họ lên sau lưng.
+    """
+    from datetime import datetime, timezone
+    dau = {"level": str(level or ""), "source": "user",
+           "at": datetime.now(timezone.utc).isoformat(timespec="seconds")}
+    runtime_cfg["preset_choice"] = dau
+    return dau
 
 
 def current_preset(runtime_cfg: dict) -> str:
@@ -8181,6 +8194,9 @@ async def runtime_preset_set(level: str = Form(...)):
     cfg = cfgmod.read_settings()
     runtime_cfg = cfg.setdefault("context_runtime", {})
     runtime_cfg["mode"] = preset["mode"]
+    # Ký tên TRƯỚC khi ghi: từ đây trở đi mức này là quyết định của người dùng, không bản
+    # cập nhật nào được nâng nó lên sau lưng.
+    _ky_ten_muc(runtime_cfg, key)
 
     # Đường nào cần hạn mức mà chưa khai thì TỰ KHAI cho provider đang dùng. Không làm bước
     # này thì bấm một mức sẽ bật một đường fail-closed: knob xoay được, đèn không sáng - đúng
@@ -8247,7 +8263,11 @@ async def runtime_mode_set(mode: str = Form(...)):
         return JSONResponse({"ok": False, "error": f"mode '{mode}' không hợp lệ",
                              "hop_le": list(_RUNTIME_MODES)}, status_code=400)
     cfg = cfgmod.read_settings()
-    cfg.setdefault("context_runtime", {})["mode"] = value
+    runtime_cfg = cfg.setdefault("context_runtime", {})
+    runtime_cfg["mode"] = value
+    # Đổi công tắc trùm cũng là một quyết định về mức tiết kiệm: hạ xuống shadow là cố ý tắt
+    # hết. Không ký ở đây thì lần nâng mặc định sau sẽ kéo mode trở lại canary sau lưng.
+    _ky_ten_muc(runtime_cfg, current_preset(runtime_cfg))
     cfgmod.write_settings(cfg)
     active = [k for k, v in (cfgmod.read_settings().get("context_runtime") or {}).items()
               if isinstance(v, dict) and int(v.get("allocation_basis_points") or 0) > 0]
@@ -8331,7 +8351,11 @@ async def runtime_canary_set(
     if status:
         return JSONResponse(payload, status_code=status)
     entry["allocation_basis_points"] = payload["allocation_basis_points"]
-    cfg.setdefault("context_runtime", {})[path] = entry
+    rt = cfg.setdefault("context_runtime", {})
+    rt[path] = entry
+    # Người vào tận phần Nâng cao chỉnh từng đường là người có ý kiến riêng. Ký tên để bản
+    # cập nhật sau không nâng cấu hình tay của họ lên theo mặc định mới.
+    _ky_ten_muc(rt, current_preset(rt))
     cfgmod.write_settings(cfg)
     # Không cần restart: read_settings cache theo mtime nên lượt kế tiếp đã ăn giá trị mới.
     after = (cfgmod.read_settings().get("context_runtime") or {}).get(path) or {}

--- a/server/main.py
+++ b/server/main.py
@@ -378,6 +378,10 @@ def build_system_prompt(brain: str = "brain", include_memory: bool = True,
             base += _skill_router_block(brain, root, _skills)   # ROUTER SKILL đa-engine: list skill + cách gọi
     except Exception:
         pass
+    # Đồng hồ. Cùng một dòng với capsule của đường tiết kiệm (context_compiler.dong_ho), để
+    # bật hay tắt tiết kiệm thì Javis vẫn biết bây giờ mấy giờ y như nhau. Model không có
+    # đồng hồ, và tool `javis_now` thì không phải đường nào cũng phát tool.
+    base += "\n\n# === BÂY GIỜ ===\n" + context_compiler.dong_ho()
     try:
         # 1 dòng MỨC DÙNG để Javis TRẢ LỜI được khi user hỏi "token tiêu bao nhiêu" (chi tiết ở panel).
         _t = usage_store.summary().get("today", {}).get("total", {})
@@ -7757,6 +7761,7 @@ async def _uoc_tinh_tiet_kiem(brain: str = "brain") -> dict:
         vien = tok(cc.CORE_CONTRACT
                    + "Runtime identity: provider=x; model=y. "
                    + cc.ContextCompiler._channel_contract("dashboard")
+                   + cc.dong_ho()
                    + cc.ContextCompiler._output_contract_text("dashboard"))
     except Exception:  # noqa: BLE001
         return {}

--- a/server/main.py
+++ b/server/main.py
@@ -1052,6 +1052,7 @@ async def _execute_write_proposal(plan, provider: str, api_key: str, model: str,
         await ws.send_text(json.dumps({
             "type": "response", "content": text, "engine": "javis-gateway",
             "model": actual_model, "session_id": session_id,
+            **_ctx_frame(runtime_trace, tokens_in),
         }))
         return text, actual_model
 
@@ -1068,6 +1069,7 @@ async def _execute_write_proposal(plan, provider: str, api_key: str, model: str,
         await ws.send_text(json.dumps({
             "type": "response", "content": text, "engine": "javis-gateway",
             "model": actual_model, "session_id": session_id,
+            **_ctx_frame(runtime_trace, tokens_in),
         }))
         return text, actual_model
 
@@ -1130,6 +1132,7 @@ async def _execute_write_proposal(plan, provider: str, api_key: str, model: str,
     await ws.send_text(json.dumps({
         "type": "response", "content": text, "engine": provider,
         "model": actual_model, "session_id": session_id,
+        **_ctx_frame(runtime_trace, tokens_in),
     }))
     return text, actual_model
 
@@ -1158,6 +1161,7 @@ async def _execute_write_confirmation(plan, ws, session_id: str, runtime_trace,
         await ws.send_text(json.dumps({
             "type": "response", "content": text, "engine": "javis-gateway",
             "model": model, "session_id": session_id,
+            **_ctx_frame(runtime_trace, 0),
         }))
         return text
 
@@ -1174,6 +1178,7 @@ async def _execute_write_confirmation(plan, ws, session_id: str, runtime_trace,
         await ws.send_text(json.dumps({
             "type": "response", "content": text, "engine": "javis-gateway",
             "model": model, "session_id": session_id,
+            **_ctx_frame(runtime_trace, 0),
         }))
         return text
 
@@ -1194,6 +1199,7 @@ async def _execute_write_confirmation(plan, ws, session_id: str, runtime_trace,
         await ws.send_text(json.dumps({
             "type": "response", "content": text, "engine": "javis-gateway",
             "model": model, "session_id": session_id,
+            **_ctx_frame(runtime_trace, 0),
         }))
         return text
 
@@ -1239,6 +1245,7 @@ async def _execute_write_confirmation(plan, ws, session_id: str, runtime_trace,
     await ws.send_text(json.dumps({
         "type": "response", "content": text, "engine": "javis-gateway",
         "model": model, "session_id": session_id,
+        **_ctx_frame(runtime_trace, 0),
     }))
     return text
 
@@ -1493,6 +1500,7 @@ async def _execute_readonly_orchestrator(plan, provider: str, api_key: str, mode
         "model": result.model or model or "?", "session_id": session_id,
         "task_id": result.task_id, "stop_reason": result.stop_reason,
         "evidence_refs": list(result.evidence_refs),
+        **_ctx_frame(runtime_trace, 0),
     }))
     return result.text, result.model or model or "?"
 
@@ -1545,6 +1553,7 @@ async def _execute_readonly_path(plan, provider: str, api_key: str, model: str,
         await ws.send_text(json.dumps({
             "type": "response", "content": final_text, "engine": "javis-gateway",
             "model": actual_model, "session_id": session_id,
+            **_ctx_frame(runtime_trace, tokens_in),
         }))
         return final_text, actual_model
 
@@ -1571,6 +1580,7 @@ async def _execute_readonly_path(plan, provider: str, api_key: str, model: str,
         await ws.send_text(json.dumps({
             "type": "response", "content": final_text, "engine": "javis-gateway",
             "model": actual_model, "session_id": session_id,
+            **_ctx_frame(runtime_trace, tokens_in),
         }))
         return final_text, actual_model
 
@@ -1606,6 +1616,7 @@ async def _execute_readonly_path(plan, provider: str, api_key: str, model: str,
         await ws.send_text(json.dumps({
             "type": "response", "content": final_text, "engine": "javis-gateway",
             "model": actual_model, "session_id": session_id,
+            **_ctx_frame(runtime_trace, tokens_in),
         }))
         return final_text, actual_model
 
@@ -1672,6 +1683,7 @@ async def _execute_readonly_path(plan, provider: str, api_key: str, model: str,
     await ws.send_text(json.dumps({
         "type": "response", "content": final_text, "engine": provider,
         "model": actual_model, "session_id": session_id,
+        **_ctx_frame(runtime_trace, tokens_in),
     }))
     return final_text, actual_model
 
@@ -6937,6 +6949,7 @@ async def websocket_endpoint(ws: WebSocket):
                     "type": "response", "content": final_text,
                     "engine": "javis_schedule", "model": "gateway",
                     "session_id": conv_sid,
+                    **_ctx_frame(runtime_trace, _ctx_in),
                 }))
             elif _codex_fast_plan is not None and kind in ("oauth", "cli"):
                 # ===== GÓI THUÊ BAO, ĐƯỜNG TẮT: gọi thẳng model một vòng =====
@@ -7158,6 +7171,7 @@ async def websocket_endpoint(ws: WebSocket):
                         "type": "response", "content": final_text,
                         "engine": "javis-gateway", "model": api_model or "?",
                         "session_id": conv_sid,
+                        **_ctx_frame(runtime_trace, _ctx_in),
                     }))
                 elif kind == "api" and api_key:
                     # Mọi exception trong prepare của canary phải rơi tiếp xuống nhánh
@@ -7220,6 +7234,7 @@ async def websocket_endpoint(ws: WebSocket):
                         "type": "response", "content": final_text,
                         "engine": "javis-gateway", "model": api_model or "?",
                         "session_id": conv_sid, "task_id": runtime_trace.task_id,
+                        **_ctx_frame(runtime_trace, _ctx_in),
                     }))
                 elif readonly_plan and readonly_plan.action == "execute":
                     used_fast_path = True
@@ -7239,6 +7254,7 @@ async def websocket_endpoint(ws: WebSocket):
                         "type": "response", "content": final_text,
                         "engine": "javis-gateway", "model": api_model or "?",
                         "session_id": conv_sid,
+                        **_ctx_frame(runtime_trace, _ctx_in),
                     }))
                 elif fast_plan and fast_plan.action == "execute":
                     used_fast_path = True
@@ -7258,6 +7274,7 @@ async def websocket_endpoint(ws: WebSocket):
                         "type": "response", "content": final_text,
                         "engine": "javis-gateway", "model": api_model or "?",
                         "session_id": conv_sid,
+                        **_ctx_frame(runtime_trace, _ctx_in),
                     }))
                 else:
                     # ===== API/OAuth: Phase 8 sources canary, fallback độc lập về legacy =====
@@ -7294,6 +7311,7 @@ async def websocket_endpoint(ws: WebSocket):
                             "type": "response", "content": final_text,
                             "engine": "javis-gateway", "model": api_model or "?",
                             "session_id": conv_sid,
+                            **_ctx_frame(runtime_trace, _ctx_in),
                         }))
                     else:
                         sysprompt = (_phase8_plan.system_prompt
@@ -7695,7 +7713,10 @@ async def runtime_diagnostics(hours: float = Query(24.0), limit: int = Query(200
             # là ba cái tên, người dùng bấm mà không biết đổi được gì.
             "uoc_tinh": await _uoc_tinh_tiet_kiem(brain),
             # Và con số ĐO ĐƯỢC từ chính các lượt đã chạy, đáng tin hơn hẳn ước lượng.
-            "do_duoc": _do_duoc_tiet_kiem(snapshot.get("tasks") or [])}
+            "do_duoc": _do_duoc_tiet_kiem(snapshot.get("tasks") or []),
+            # Lý do LẶP LẠI nhiều nhất khiến lượt không đi được đường tắt. Đây là câu trả lời
+            # cho "sao chưa lần nào thấy chữ Tức thì" - thứ trước đây chỉ đoán được.
+            "vi_sao": _vi_sao_chua_di_tat(snapshot.get("tasks") or [])}
 
 
 def _ctx_frame(trace, tokens_in) -> dict:
@@ -7845,6 +7866,29 @@ def _do_duoc_tiet_kiem(tasks: list) -> dict:
     if out["du_du_lieu"] and out["tb_cu"] > 0:
         out["phan_tram"] = max(0, min(99, round((1 - out["tb_moi"] / out["tb_cu"]) * 100)))
     return out
+
+
+def _vi_sao_chua_di_tat(tasks: list) -> dict:
+    """Gộp lý do của những lượt KHÔNG đi đường tắt, xếp theo số lần.
+
+    Vì sao cần con số gộp trong khi bảng "Lượt gần nhất" đã ghi lý do từng lượt: một lý do
+    lặp lại 18 trên 20 lượt là một CÁI HỎNG, còn cùng lý do đó xuất hiện 2 lần là chuyện
+    bình thường. Bảng từng dòng không phân biệt nổi hai ca đó, và chủ repo đã phải nói bằng
+    lời "chưa lần nào thấy chữ Tức thì" thay vì chỉ vào một con số. Đó là lúc trang chẩn đoán
+    thua: người dùng biết có gì đó sai mà trang không nói được sai ở đâu.
+    """
+    dem: dict[str, int] = {}
+    tong = 0
+    for t in tasks or []:
+        if str(t.get("execution_path") or "") == "fast":
+            continue
+        ly = str(t.get("ly_do") or "").strip()
+        if not ly:
+            continue
+        tong += 1
+        dem[ly] = dem.get(ly, 0) + 1
+    top = sorted(dem.items(), key=lambda kv: (-kv[1], kv[0]))[:3]
+    return {"tong": tong, "top": [{"ma": k, "so_lan": v} for k, v in top]}
 
 
 def _engine_runtime_view(settings: dict) -> dict:

--- a/tests/python/test_adaptive_runtime_hardening.py
+++ b/tests/python/test_adaptive_runtime_hardening.py
@@ -24,6 +24,14 @@ from context_runtime import ObserveRuntime
 from evidence_store import EvidenceStore, redact
 from memory_index import MemoryIndex
 
+# Ghim đồng hồ: capsule mang theo giờ thật, nên từ 0.14.6 thời điểm biên soạn cũng là một
+# đầu vào của capsule hash. Không ghim thì hai lần biên soạn rơi hai bên mốc phút sẽ ra hai
+# hash khác nhau và bất biến dưới đây thỉnh thoảng đỏ - loại đỏ tệ nhất vì chạy lại là xanh.
+import context_compiler as _cc
+from datetime import datetime as _dt, timedelta as _td, timezone as _tz
+_cc._DONG_HO_NOW = lambda: _dt(2026, 8, 3, 21, 34, tzinfo=_tz(_td(hours=7)))
+
+
 
 # ---------------------------------------------------------------- Phase 0-1
 

--- a/tests/python/test_context_compiler_phase4.py
+++ b/tests/python/test_context_compiler_phase4.py
@@ -14,6 +14,13 @@ from context_compiler import (
 )
 from context_runtime import ObserveRuntime
 
+# Ghim đồng hồ: capsule mang theo giờ thật, nên từ 0.14.6 thời điểm biên soạn cũng là một
+# đầu vào của capsule hash. Không ghim thì hai lần biên soạn rơi hai bên mốc phút sẽ ra hai
+# hash khác nhau và bất biến dưới đây thỉnh thoảng đỏ - loại đỏ tệ nhất vì chạy lại là xanh.
+import context_compiler as _cc
+from datetime import datetime as _dt, timedelta as _td, timezone as _tz
+_cc._DONG_HO_NOW = lambda: _dt(2026, 8, 3, 21, 34, tzinfo=_tz(_td(hours=7)))
+
 
 def _tool(name, description, schema=None):
     return {"fn": name, "name": name, "server": "synthetic", "description": description,
@@ -87,8 +94,10 @@ def test_fast_capsule_has_source_map_and_is_within_final_budget(tmp_path):
     assert result.trace_report["estimated_input_tokens"] <= result.trace_report["max_input_tokens"]
     assert result.trace_report["preflight_decision"] == "would_allow"
     assert result.trace_report["observe_only"] is True
+    # "time" là món bắt buộc từ 0.14.6: đường tắt không phát tool nào nên nếu capsule không
+    # mang theo giờ thì model không có cách nào biết bây giờ mấy giờ, và nó sẽ bịa lý do.
     assert set(result.capsule.source_map) == {
-        "core", "identity", "channel", "output", "objective"
+        "core", "identity", "channel", "time", "output", "objective"
     }
     assert result.trace_report["source_map_hash"]
 

--- a/tests/python/test_dong_ho.py
+++ b/tests/python/test_dong_ho.py
@@ -1,0 +1,106 @@
+"""Javis phải biết BÂY GIỜ MẤY GIỜ trên mọi đường, kể cả đường tắt không phát tool.
+
+    python tests/run.py dong_ho
+
+Lỗi thật chủ repo chụp lại: hỏi "giờ Việt Nam là mấy giờ" thì Javis trả lời "MCP server của
+Javis hiện đang mất kết nối... khi nào kết nối lại em sẽ gọi tool javis_now". Không có server
+nào mất kết nối cả. Sự thật là lượt đó đi ĐƯỜNG TẮT của mức Siêu tiết kiệm, mà đường tắt gửi
+capsule KHÔNG KÈM TOOL NÀO - đó chính là chỗ nó tiết kiệm. Model không có đồng hồ, không có
+tool, nên nó làm cái tệ nhất: bịa ra một lý do nghe hợp lý.
+
+Bộ lọc câu hỏi CÓ chặn "bây giờ", "hôm nay"... nhưng chặn theo từ khoá là trò đuổi bắt, và
+"giờ Việt Nam là mấy giờ" lọt qua đúng như vậy. Nên chữa ở gốc: mọi prompt Javis gửi đi đều
+mang theo một dòng giờ thật. Khoảng 30 token, đổi lấy việc không còn cửa nào để bịa.
+"""
+from _paths import ROOT, SERVER  # noqa: E402,F401
+import asyncio
+import os
+import re
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+os.environ["JAVIS_STATE_DIR"] = tempfile.mkdtemp(prefix="javis-dongho-")
+
+import context_compiler as cc  # noqa: E402
+import main  # noqa: E402
+
+_fails = []
+
+
+def check(name, cond):
+    print(("ok   " if cond else "FAIL ") + name)
+    if not cond:
+        _fails.append(name)
+
+
+# ---- 1. Dòng giờ nói đúng thứ nó phải nói ----
+_moc = datetime(2026, 8, 3, 21, 34, tzinfo=timezone(timedelta(hours=7)))   # thứ Hai
+_d = cc.dong_ho(_moc)
+check("có giờ và phút", "21:34" in _d)
+check("có thứ trong tuần bằng tiếng Việt", "Thứ Hai" in _d)
+check("có ngày tháng năm kiểu Việt Nam", "03/08/2026" in _d)
+check("nói rõ múi giờ", "UTC+7" in _d)
+check("không dùng em dash", "—" not in _d)
+# Nói thẳng là không cần gọi tool, nếu không model vẫn đi tìm tool rồi báo không có.
+check("nói rõ khỏi cần gọi tool", "không cần gọi tool" in _d)
+
+# Múi giờ là UTC+7 CỐ ĐỊNH, không đọc múi giờ của máy chủ - VPS thường chạy UTC.
+_utc = datetime(2026, 8, 3, 14, 34, tzinfo=timezone.utc).astimezone(
+    timezone(timedelta(hours=7)))
+check("14:34 UTC là 21:34 giờ Việt Nam", "21:34" in cc.dong_ho(_utc))
+
+# Không ghim thì phải là giờ THẬT lúc chạy, không phải một hằng số ai đó quên thay.
+_that = cc.dong_ho()
+_hom_nay = datetime.now(timezone(timedelta(hours=7)))
+check("không ghim thì lấy đúng ngày đang chạy",
+      _hom_nay.strftime("%d/%m/%Y") in _that)
+check("và đúng giờ đang chạy", _hom_nay.strftime("%H:%M") in _that
+      or (_hom_nay + timedelta(minutes=1)).strftime("%H:%M") in _that)
+
+# ---- 2. Capsule của ĐƯỜNG TẮT phải mang theo giờ. Đây là chỗ lỗi thật nằm ----
+from capability_registry import CapabilityRegistry  # noqa: E402
+
+_reg_dir = tempfile.mkdtemp(prefix="javis-dongho-reg-")
+_reg = CapabilityRegistry(_reg_dir)
+_reg.refresh_tools("brain-a", [], {})
+_reg.refresh_model_profile("groq", "model-a", "api", True, {"observed": True})
+_req = cc.CompileRequest(task_id="t1", step_id="s1", objective="giờ Việt Nam là mấy giờ",
+                         brain="brain-a", channel="dashboard", provider="groq",
+                         model="model-a", model_kind="api")
+_kq = cc.ContextCompiler(_reg).compile_shadow(_req, {"selected": []})
+check("biên soạn được capsule", _kq.status == "compiled")
+check("capsule đi đường tắt", _kq.capsule.path == "fast")
+_sys = _kq.capsule.rendered_request["messages"][0]["content"]
+check("CANARY: capsule đường tắt CÓ mang theo giờ", "giờ Việt Nam (UTC+7)" in _sys)
+check("giờ là món BẮT BUỘC, có tên riêng trong sổ nguồn",
+      "time" in (_kq.capsule.source_map or {}))
+# Đường tắt không phát tool - đúng thiết kế. Chính vì vậy giờ mới phải nằm sẵn trong capsule.
+check("và đúng là không có tool nào để mà gọi", _kq.capsule.capabilities == ())
+
+# ---- 3. Đường ĐẦY ĐỦ cũng phải có, nếu không thì bật/tắt tiết kiệm lại ra hai hành vi ----
+_full = main.build_system_prompt("brain")
+check("prompt đầy đủ cũng mang theo giờ", "giờ Việt Nam (UTC+7)" in _full)
+check("có tiêu đề dễ thấy cho khối đó", "BÂY GIỜ" in _full)
+
+# ---- 4. Bảng ước tính phải ĐẾM cả dòng giờ ----
+# Không đếm thì trang khoe một con số tiết kiệm cao hơn thực tế. Nhỏ thôi, nhưng đây đúng là
+# kiểu sai số âm thầm mà cả trang này sinh ra để chống.
+_goc_dong_ho = cc.dong_ho
+try:
+    _truoc = asyncio.run(main._uoc_tinh_tiet_kiem("brain"))
+    cc.dong_ho = lambda now=None: "X" * 30000
+    _sau = asyncio.run(main._uoc_tinh_tiet_kiem("brain"))
+finally:
+    cc.dong_ho = _goc_dong_ho
+_t = ((_truoc.get("muc") or {}).get("max") or {}).get("token_moi_request")
+_s = ((_sau.get("muc") or {}).get("max") or {}).get("token_moi_request")
+check("ước tính có đo được viên capsule", isinstance(_t, int) and _t > 0)
+check("CANARY: dòng giờ được tính vào capsule khi ước tính",
+      isinstance(_s, int) and _s > _t + 9000)
+
+print()
+if _fails:
+    print(f"THẤT BẠI {len(_fails)}: {_fails}")
+    sys.exit(1)
+print("OK - test_dong_ho: tất cả pass")

--- a/tests/python/test_duong_tat_bi_chan.py
+++ b/tests/python/test_duong_tat_bi_chan.py
@@ -1,0 +1,215 @@
+"""Vì sao mức Siêu tiết kiệm chưa chạy lần nào trên máy đấu nhiều MCP.
+
+    python tests/run.py duong_tat_bi_chan
+
+Chủ repo báo: "chưa lần nào chat anh nhìn thấy chữ Tức thì, có chỗ thì không hiện gì". Hai
+triệu chứng, hai lỗi khác nhau, và cả hai đều KHÔNG lộ ra trên máy dev.
+
+1. ĐƯỜNG TẮT BỊ CHẶN Ở MỌI LƯỢT. Cửa nhận lượt xét `candidate_count > 0` - số ứng viên dò
+   được bằng CHỮ, đếm TRƯỚC khi chấm điểm và TRƯỚC khi lọc quyền. Máy đấu vài trăm tool MCP
+   (Gmail, Drive, Lịch, quảng cáo...) thì gần như câu tiếng Việt nào cũng dò trúng vài tool
+   qua một từ chung, nên điều kiện đó ĐÚNG với mọi lượt và đường tắt không bao giờ chạy. Càng
+   đấu nhiều nguồn càng không tiết kiệm được - ngược hẳn thứ nó hứa. Máy dev có kho tool gần
+   như rỗng nên mọi test đều xanh trong khi máy thật đứng hình.
+
+2. NHIỀU NHÁNH TRẢ LỜI KHÔNG GẮN NHÃN. Dòng "chế độ + token" dưới câu trả lời do gói tin
+   `response` mang theo, mà chỉ vài nhánh gắn nó. Nhánh gateway (nhắc hẹn), nhánh tra cứu,
+   nhánh từ chối vì vượt hạn mức... đều gửi câu trả lời trần - và người dùng thấy đúng cái
+   họ mô tả: có lượt hiện, có lượt không hiện gì.
+"""
+from _paths import ROOT, SERVER  # noqa: E402,F401
+import ast
+import os
+import sys
+import tempfile
+
+os.environ["JAVIS_STATE_DIR"] = tempfile.mkdtemp(prefix="javis-duongtat-")
+
+import config as cfg  # noqa: E402
+import fast_path_runtime as fp  # noqa: E402
+
+_fails = []
+
+
+def check(name, cond):
+    print(("ok   " if cond else "FAIL ") + name)
+    if not cond:
+        _fails.append(name)
+
+
+# ============================================================
+# 1. Cửa nhận lượt xét ĐIỂM, không xét số lần dò trúng chữ
+# ============================================================
+_pol = fp.CanaryPolicy.from_settings(cfg.read_settings())
+check("có ngưỡng điểm khớp", 0.0 < _pol.min_resolver_score <= 1.0)
+# Phải nằm trong settings.json để người vận hành chỉnh được. Mã có giá trị dự phòng, nên
+# thiếu khoá này thì hành vi vẫn đúng - chỉ có điều không ai tìm thấy nút mà vặn.
+check("ngưỡng có mặt trong cấu hình mặc định để chỉnh được",
+      "min_resolver_score" in ((cfg._DEFAULT["context_runtime"] or {}).get("canary") or {}))
+check("ngưỡng đọc được từ cấu hình",
+      fp.CanaryPolicy.from_settings(
+          {"context_runtime": {"canary": {"min_resolver_score": 0.9}}}).min_resolver_score == 0.9)
+
+
+class _Runtime:
+    def __init__(self):
+        self.events = []
+
+    def pin_execution_path(self, trace, path, bucket, ver, reason):
+        return path
+
+    def record_runtime_event(self, trace, ten, data):
+        self.events.append((ten, data))
+
+    def admit_quota(self, *a, **k):
+        class _Ok:
+            allowed = True
+            reason = ""
+            reservation_id = "r1"
+        return _Ok()
+
+
+class _Registry:
+    def inventory_status(self, brain):
+        return {"ready": True, "age_seconds": 1.0, "revision": "reg_x"}
+
+
+class _Resolver:
+    """Giả lập máy THẬT: kho vài trăm tool nên câu nào cũng dò trúng, nhưng không cái nào
+    thật sự khớp. `ranked` là danh sách đã chấm điểm."""
+
+    def __init__(self, diem, so_ung_vien=180):
+        self.diem, self.so = diem, so_ung_vien
+
+    def resolve(self, objective, brain, actor):
+        return {"policy_version": "p", "registry_revision": "reg_x",
+                "candidate_count": self.so, "selected_count": 0,
+                "ranked": [{"capability_id": "c1", "name": "x", "score": self.diem}],
+                "filtered": {"required_mode": 12}, "miss_class": "coverage"}
+
+
+class _Capsule:
+    capsule_hash = "h"
+    rendered_request = {"messages": [{"role": "system", "content": "x"}]}
+    path = "fast"
+
+
+class _Compiled:
+    status = "compiled"
+    capsule = _Capsule()
+    trace_report = {"status": "compiled", "path": "fast", "estimated_input_tokens": 100,
+                    "max_input_tokens": 10000, "reserved_output_tokens": 1000,
+                    "preflight_decision": "would_allow"}
+
+
+class _Compiler:
+    def compile_canary(self, request, resolution):
+        return _Compiled()
+
+
+class _Trace:
+    session_id = "s1"
+    task_id = "t1"
+    step_id = "st1"
+    channel = "dashboard"
+    registry_revision = "reg_x"
+
+
+def _lam(diem, so_ung_vien=180):
+    rt = _Runtime()
+    admission = fp.FastPathCanary(
+        runtime=rt, registry=_Registry(), resolver=_Resolver(diem, so_ung_vien),
+        compiler=_Compiler(),
+        settings_reader=lambda: {"context_runtime": {
+            "mode": "canary",
+            "subscription_context": {"context_window": 180000, "reserved_output_tokens": 8000},
+            "canary": {"allocation_basis_points": 10000, "channels": ["dashboard"],
+                       "provider_kinds": ["api", "oauth", "cli"]},
+        }},
+    )
+    return admission.prepare(_Trace(), "giờ Việt Nam là mấy giờ", "brain-a", "dashboard",
+                             "anthropic", "claude", "cli"), rt
+
+
+# Đây là ca THẬT trên máy chủ repo: 180 tool dò trúng, không cái nào khớp thật.
+_plan, _rt = _lam(diem=0.05)
+check("CANARY: dò trúng nhiều nhưng điểm thấp thì VẪN đi đường tắt",
+      _plan.action == "execute")
+check("và lý do không còn là 'mơ hồ'", _plan.reason != "capability_ambiguous")
+
+# Có cái SUÝT khớp thì vẫn phải nhường đường thường - bộ lọc không được nới thành vô dụng.
+_plan, _ = _lam(diem=0.9)
+check("có capability suýt khớp thì nhường đường thường",
+      _plan.action == "legacy" and _plan.reason == "capability_ambiguous")
+
+# Ngay ở ngưỡng thì phải chặn (>=), không được lọt.
+_plan, _ = _lam(diem=_pol.min_resolver_score)
+check("đúng ngay ngưỡng thì chặn", _plan.reason == "capability_ambiguous")
+
+# Không có ứng viên nào thì đương nhiên đi tắt.
+_plan, _ = _lam(diem=0.0, so_ung_vien=0)
+check("kho tool rỗng thì đi tắt như cũ", _plan.action == "execute")
+
+# Điểm phải được ghi lại, nếu không thì lần sau lại đoán mò như lần này.
+_plan, _rt = _lam(diem=0.05)
+_ev = dict(_rt.events).get("resolver.canary") or {}
+check("có ghi lại điểm cao nhất để chẩn đoán", "top_score" in _ev)
+check("và ghi cả ngưỡng đang dùng", "min_resolver_score" in _ev)
+
+
+# ============================================================
+# 2. Mọi nhánh trả lời trong lượt chat phải gắn nhãn chế độ
+# ============================================================
+_src = (ROOT / "server" / "main.py").read_text(encoding="utf-8")
+_lines = _src.split("\n")
+_thieu = []
+for i, l in enumerate(_lines):
+    if '"type": "response"' not in l:
+        continue
+    j = i
+    while j < len(_lines) and not _lines[j].strip().startswith("}))"):
+        j += 1
+    if j >= len(_lines) or j - i > 10:
+        continue
+    if "_ctx_frame" not in "\n".join(_lines[i:j + 1]):
+        _thieu.append(i + 1)
+check(f"CANARY: mọi gói trả lời đều mang nhãn chế độ (thiếu ở dòng {_thieu})", not _thieu)
+
+# Và nhãn đó phải nói được đường tắt, nếu không thì gắn cũng bằng thừa.
+_ast = ast.parse(_src)
+check("hàm dựng nhãn có thật",
+      any(isinstance(n, ast.FunctionDef) and n.name == "_ctx_frame" for n in ast.walk(_ast)))
+
+
+# ============================================================
+# 3. Trang phải nói được lý do LẶP LẠI, không bắt người dùng tự đếm
+# ============================================================
+import main  # noqa: E402
+
+# Lý do nhiều nhất CỐ Ý đứng sau theo bảng chữ cái: xếp nhầm theo tên thay vì theo số lần
+# thì dữ liệu này lộ ra ngay, còn dữ liệu thuận chiều thì hai cách xếp cho cùng kết quả và
+# test đó không canh được gì.
+_vs = main._vi_sao_chua_di_tat([
+    {"execution_path": "sources", "ly_do": "registry_stale"},
+    {"execution_path": "sources", "ly_do": "registry_stale"},
+    {"execution_path": "legacy", "ly_do": "capability_ambiguous"},
+    {"execution_path": "fast", "ly_do": "admitted"},
+    {"execution_path": "sources", "ly_do": ""},
+])
+check("đếm đúng số lượt không đi tắt", _vs["tong"] == 3)
+check("xếp lý do nhiều nhất lên đầu",
+      _vs["top"] and _vs["top"][0]["ma"] == "registry_stale"
+      and _vs["top"][0]["so_lan"] == 2)
+check("lượt đã đi tắt không bị tính là lý do",
+      all(x["ma"] != "admitted" for x in _vs["top"]))
+
+_console = (ROOT / "dashboard" / "console.js").read_text(encoding="utf-8")
+check("giao diện có vẽ khối lý do", "_viSao" in _console and "vi_sao" in _console)
+check("và dịch mã lý do sang tiếng Việt", "_lyDo(x.ma)" in _console)
+check("máy chủ có trả khối đó", '"vi_sao"' in _src)
+
+print()
+if _fails:
+    print(f"THẤT BẠI {len(_fails)}: {_fails}")
+    sys.exit(1)
+print("OK - test_duong_tat_bi_chan: tất cả pass")

--- a/tests/python/test_muc_mac_dinh.py
+++ b/tests/python/test_muc_mac_dinh.py
@@ -1,0 +1,257 @@
+"""Đổi mặc định mức tiết kiệm phải TỚI ĐƯỢC máy đã cài, và không giẫm lên ai đã tự chọn.
+
+    python tests/run.py muc_mac_dinh
+
+Cái bẫy file này canh. `write_settings` ghi lại TOÀN BỘ config đã trộn, nên ngay lần đầu
+người dùng bấm bất cứ nút nào, giá trị mặc định của NGÀY HÔM ĐÓ bị đóng băng vào
+settings.json; `read_settings` lại trộn file ĐÈ LÊN mặc định. Hệ quả: sau này nâng mặc định
+lên mức Tối ưu hay Siêu tiết kiệm thì máy đã cài rồi không bao giờ thấy - mặc định mới chỉ
+tới được máy cài mới tinh. Đúng con bệnh đã cắn `provider_kinds` hồi 0.12.4, lần này rơi vào
+thứ quyết định mỗi lượt chat tốn bao nhiêu token.
+
+Vì sao cần chữ ký chứ không nâng đại: số 0 trong file có HAI nghĩa - "cố ý chọn Tắt" và
+"chưa ai chọn gì". Nên mọi endpoint đổi mức đều đóng dấu `preset_choice.source = "user"`, và
+có dấu thì bản cập nhật không đụng vào.
+
+Test ở đây GIẢ LẬP việc nâng mặc định (đổi `cfg.PRESET_MAC_DINH` rồi đọc lại) thay vì chờ
+tới ngày thật sự nâng. Một cơ chế di trú chỉ chạy đúng một lần trong đời mà không có test thì
+tới hôm dùng mới biết nó hỏng, và lúc đó thì đã phát ra cho người dùng rồi.
+"""
+from _paths import ROOT, SERVER  # noqa: E402,F401
+import asyncio
+import json
+import os
+import sys
+import tempfile
+
+os.environ["JAVIS_STATE_DIR"] = tempfile.mkdtemp(prefix="javis-macdinh-")
+
+import config as cfg  # noqa: E402
+import main  # noqa: E402
+
+_fails = []
+
+
+def check(name, cond):
+    print(("ok   " if cond else "FAIL ") + name)
+    if not cond:
+        _fails.append(name)
+
+
+def _ghi(raw: dict):
+    """Ghi settings.json THÔ (không qua write_settings) rồi xoá cache đọc.
+
+    Phải xoá cache bằng tay: `read_settings` nhớ theo (mtime, size) của file, mà test đổi
+    `PRESET_MAC_DINH` trong bộ nhớ chứ không đụng file - cache hit sẽ trả về bản đã tính
+    bằng mặc định CŨ và test thành ra đo cái bóng của chính nó.
+    """
+    cfg.SETTINGS_PATH.write_text(json.dumps(raw, ensure_ascii=False), encoding="utf-8")
+    cfg._SETTINGS_CACHE["sig"] = None
+    cfg._SETTINGS_CACHE["cfg"] = None
+
+
+def _doc_voi_mac_dinh(muc: str) -> dict:
+    """Đọc settings như thể bản đang chạy có mức xuất xưởng là `muc`."""
+    cu = cfg.PRESET_MAC_DINH
+    cfg.PRESET_MAC_DINH = muc
+    cfg._SETTINGS_CACHE["sig"] = None
+    try:
+        return cfg.read_settings().get("context_runtime") or {}
+    finally:
+        cfg.PRESET_MAC_DINH = cu
+        cfg._SETTINGS_CACHE["sig"] = None
+
+
+def _bp(rt: dict, ten: str) -> int:
+    return int(((rt.get(ten) or {}).get("allocation_basis_points")) or 0)
+
+
+# Máy cài từ lâu: settings.json đã đóng băng mặc định của ngày hôm đó (mọi đường 0, mode
+# shadow) và KHÔNG có chữ ký nào, vì hồi đó chưa có khái niệm chữ ký.
+MAY_CU = {
+    "context_runtime": {
+        "mode": "shadow",
+        "canary": {"allocation_basis_points": 0, "provider_kinds": ["api"]},
+        "conversation_state_canary": {"allocation_basis_points": 0},
+        "memory_canary": {"allocation_basis_points": 0},
+        "lazy_skill_canary": {"allocation_basis_points": 0},
+    }
+}
+
+# ---- 1. Một nguồn sự thật cho bảng mức ----
+check("bảng mức nằm ở config, main không chép lại",
+      set(cfg.PRESET_DUONG) == set(main.RUNTIME_PRESETS))
+for _k in cfg.PRESET_DUONG:
+    check(f"mức '{_k}': main dùng đúng bảng của config",
+          main.RUNTIME_PRESETS[_k]["duong"] == cfg.PRESET_DUONG[_k]["duong"]
+          and main.RUNTIME_PRESETS[_k]["mode"] == cfg.PRESET_DUONG[_k]["mode"])
+_keys = main._canary_keys()
+for _k, _p in cfg.PRESET_DUONG.items():
+    for _d in _p["duong"]:
+        check(f"mức '{_k}' trỏ vào đường có thật: {_d}", _d in _keys)
+check("mức xuất xưởng phải là một mức có thật", cfg.PRESET_MAC_DINH in cfg.PRESET_DUONG)
+
+# ---- 2. Máy CÀI MỚI ăn đúng mức xuất xưởng ----
+try:
+    cfg.SETTINGS_PATH.unlink()
+except OSError:
+    pass
+cfg._SETTINGS_CACHE["sig"] = None
+check("máy mới tinh chạy đúng mức xuất xưởng của bản này",
+      main.current_preset(cfg.read_settings().get("context_runtime") or {})
+      == cfg.PRESET_MAC_DINH)
+
+# ---- 3. Máy CŨ cũng phải ăn được mặc định mới. Đây là cái bẫy chính ----
+_ghi(MAY_CU)
+_rt = _doc_voi_mac_dinh("max")
+check("máy cũ đóng băng mặc định vẫn được nâng lên mức mới",
+      main.current_preset(_rt) == "max")
+check("công tắc trùm được nâng theo, không để knob xoay mà đèn không sáng",
+      _rt.get("mode") == "canary")
+for _d in cfg.PRESET_DUONG["max"]["duong"]:
+    check(f"máy cũ: '{_d}' đã bật thật", _bp(_rt, _d) == 10000)
+
+_ghi(MAY_CU)
+_rt = _doc_voi_mac_dinh("saving")
+check("nâng mặc định lên Tối ưu thì máy cũ được đúng ba đường của Tối ưu",
+      main.current_preset(_rt) == "saving")
+check("Tối ưu KHÔNG kéo theo đường tắt", _bp(_rt, "canary") == 0)
+
+# Mức xuất xưởng hiện tại là "off" nên hàm phải đứng im - đổi hành vi ngay hôm nay là đổi
+# sau lưng người đang dùng, mà bản này chỉ dựng sẵn cơ chế.
+_ghi(MAY_CU)
+check("mức xuất xưởng của bản NÀY chưa đổi gì của ai",
+      main.current_preset(cfg.read_settings().get("context_runtime") or {}) == "off")
+
+# Mức không bật đường nào thì không có lý do gì đụng tới công tắc trùm - công tắc đó dùng
+# chung với các phase khác (readonly, orchestrator, write).
+_may_tat_han = json.loads(json.dumps(MAY_CU))
+_may_tat_han["context_runtime"]["mode"] = "off"
+_ghi(_may_tat_han)
+_rt = _doc_voi_mac_dinh("off")
+check("mức Tắt không tự kéo công tắc trùm của ai lên", _rt.get("mode") == "off")
+
+# ---- 4. Có chữ ký thì không ai được đụng vào ----
+_da_chon_tat = json.loads(json.dumps(MAY_CU))
+_da_chon_tat["context_runtime"]["preset_choice"] = {
+    "level": "off", "source": "user", "at": "2026-08-03T00:00:00+00:00"}
+_ghi(_da_chon_tat)
+_rt = _doc_voi_mac_dinh("max")
+check("người đã cố ý chọn Tắt thì bản cập nhật KHÔNG bật lại",
+      main.current_preset(_rt) == "off")
+check("mode cũng giữ nguyên khi đã có chữ ký", _rt.get("mode") == "shadow")
+
+_da_chon_saving = json.loads(json.dumps(MAY_CU))
+_da_chon_saving["context_runtime"]["mode"] = "canary"
+for _d in cfg.PRESET_DUONG["saving"]["duong"]:
+    _da_chon_saving["context_runtime"][_d] = {"allocation_basis_points": 10000}
+_da_chon_saving["context_runtime"]["preset_choice"] = {
+    "level": "saving", "source": "user", "at": "2026-08-03T00:00:00+00:00"}
+_ghi(_da_chon_saving)
+_rt = _doc_voi_mac_dinh("max")
+check("người đã chọn Tối ưu thì không bị đẩy lên Siêu tiết kiệm",
+      main.current_preset(_rt) == "saving")
+
+# ---- 5. CHỈ NÂNG, KHÔNG BAO GIỜ HẠ ----
+_may_cao = json.loads(json.dumps(MAY_CU))
+_may_cao["context_runtime"]["mode"] = "canary"
+for _d in cfg.PRESET_DUONG["max"]["duong"]:
+    _may_cao["context_runtime"][_d] = {"allocation_basis_points": 10000}
+_ghi(_may_cao)          # sửa tay settings.json: không có chữ ký nào cả
+_rt = _doc_voi_mac_dinh("saving")
+check("máy đang cao hơn mặc định thì không bị hạ xuống",
+      main.current_preset(_rt) == "max")
+check("đường tắt sửa tay vẫn còn nguyên", _bp(_rt, "canary") == 10000)
+_rt = _doc_voi_mac_dinh("off")
+check("mặc định Tắt cũng không tắt đồ của người ta", main.current_preset(_rt) == "max")
+
+# Ba mức hiện tại đều bật 100% (10000 basis point) nên không mức nào HẠ được ai - tức là
+# luật "chỉ nâng" chưa có cơ hội chứng minh mình đúng qua đường settings. Gọi thẳng hàm với
+# một mức giả bật một phần: ngày nào đó có mức rollout 30% thì luật này mới lộ ra, mà lúc đó
+# thì test phải sẵn sàng từ trước rồi.
+_gia = {"mode": "shadow", "duong": {"memory_canary": 3000}}
+cfg.PRESET_DUONG["_thu_nghiem"] = _gia
+_cu_md = cfg.PRESET_MAC_DINH
+cfg.PRESET_MAC_DINH = "_thu_nghiem"
+try:
+    _cf = {"context_runtime": {"mode": "on",
+                               "memory_canary": {"allocation_basis_points": 10000}}}
+    cfg._ap_muc_mac_dinh(_cf)
+    check("mức mặc định bật một phần KHÔNG kéo tụt máy đang bật đủ",
+          _bp(_cf["context_runtime"], "memory_canary") == 10000)
+    check("mode mạnh hơn mặc định cũng không bị hạ",
+          _cf["context_runtime"]["mode"] == "on")
+    _cf = {"context_runtime": {"mode": "shadow",
+                               "memory_canary": {"allocation_basis_points": 0}}}
+    cfg._ap_muc_mac_dinh(_cf)
+    check("còn máy đang thấp hơn thì vẫn được nâng lên đúng phần đó",
+          _bp(_cf["context_runtime"], "memory_canary") == 3000)
+finally:
+    cfg.PRESET_MAC_DINH = _cu_md
+    cfg.PRESET_DUONG.pop("_thu_nghiem", None)
+
+# ---- 6. Endpoint nào đổi mức cũng phải ký tên ----
+def _lam_moi():
+    """Về máy chưa ai chọn gì. Mỗi endpoint phải được đo trên nền sạch: đo nối đuôi nhau thì
+    chữ ký của endpoint TRƯỚC còn nằm đó và endpoint sau quên ký vẫn qua bài."""
+    try:
+        cfg.SETTINGS_PATH.unlink()
+    except OSError:
+        pass
+    cfg._SETTINGS_CACHE["sig"] = None
+
+
+def _chu_ky() -> dict:
+    return (cfg.read_settings().get("context_runtime") or {}).get("preset_choice") or {}
+
+
+async def _go():
+    _lam_moi()
+    check("nền sạch thì chưa có chữ ký nào", _chu_ky().get("source") != "user")
+
+    r = await main.runtime_preset_set(level="saving")
+    check("bấm mức → ok", isinstance(r, dict) and r.get("ok"))
+    _c = _chu_ky()
+    check("bấm mức để lại chữ ký", _c.get("source") == "user")
+    check("chữ ký nhớ đúng mức đã bấm", _c.get("level") == "saving")
+    check("chữ ký có mốc thời gian", bool(_c.get("at")))
+
+    # Bấm rồi thì bản cập nhật sau không được nâng nữa, kể cả nâng lên mức cao hơn.
+    _rt = _doc_voi_mac_dinh("max")
+    check("sau khi bấm, mặc định mới không đụng vào nữa",
+          main.current_preset(_rt) == "saving")
+
+    # Công tắc trùm: hạ về shadow là cố ý tắt hết, phải được tôn trọng y như bấm Tắt.
+    _lam_moi()
+    await main.runtime_mode_set(mode="shadow")
+    check("đổi công tắc trùm cũng ký tên", _chu_ky().get("source") == "user")
+    _rt = _doc_voi_mac_dinh("max")
+    check("hạ mode về shadow rồi thì cập nhật không kéo lên lại",
+          _rt.get("mode") == "shadow" and _bp(_rt, "memory_canary") == 0)
+
+    # Chỉnh tay một đường ở phần Nâng cao cũng là có ý kiến riêng.
+    _lam_moi()
+    r = await main.runtime_canary_set(path="memory_canary",
+                                      allocation_basis_points=5000, allow_inert=True)
+    check("chỉnh tay một đường → ok", isinstance(r, dict) and r.get("ok"))
+    check("chỉnh tay một đường cũng ký tên", _chu_ky().get("source") == "user")
+    _rt = _doc_voi_mac_dinh("max")
+    check("cấu hình chỉnh tay không bị cập nhật ghi đè",
+          _bp(_rt, "memory_canary") == 5000 and _bp(_rt, "canary") == 0)
+
+asyncio.run(_go())
+
+# ---- 7. Người dùng phải THẤY mình đang ở mặc định hay ở lựa chọn của mình ----
+_console = (ROOT / "dashboard" / "console.js").read_text(encoding="utf-8")
+check("giao diện đọc nguồn của mức đang chạy", "preset_nguon" in _console)
+check("giao diện nói rõ khi mức chỉ là mặc định", "rt-chuachon" in _console)
+_css = (ROOT / "dashboard" / "console.css").read_text(encoding="utf-8")
+check("có style cho dòng đó", ".rt-chuachon" in _css)
+_src_main = (ROOT / "server" / "main.py").read_text(encoding="utf-8")
+check("máy chủ trả nguồn của mức cho giao diện", '"preset_nguon"' in _src_main)
+
+print()
+if _fails:
+    print(f"THẤT BẠI {len(_fails)}: {_fails}")
+    sys.exit(1)
+print("OK - test_muc_mac_dinh: tất cả pass")

--- a/tests/python/test_trang_tiet_kiem.py
+++ b/tests/python/test_trang_tiet_kiem.py
@@ -215,7 +215,7 @@ check("bấm vào dòng đó thì sang trang Tiết kiệm token", 'usageGoto = 
 # 7. Panel Mức dùng cũng phải nói được chuyện này
 # ============================================================
 check("panel Mức dùng có dòng tiết kiệm", "_usageSavingRow" in _APP)
-check("nó nêu tên mức đang dùng", "Tiết kiệm token: <b>" in _APP)
+check("nó nêu tên mức đang dùng", "Tiết kiệm: <b>" in _APP)
 # Ưu tiên số ĐO ĐƯỢC, chưa có mới dùng ước lượng - và phải nói rõ cái nào là cái nào.
 check("CANARY: ưu tiên số đo thật hơn ước lượng",
       _APP.find("dod.du_du_lieu") < _APP.find("uoc.phan_tram"))

--- a/tests/python/test_trang_tiet_kiem.py
+++ b/tests/python/test_trang_tiet_kiem.py
@@ -199,9 +199,13 @@ class _TraceChua:
 check("đường chưa gán cũng quy về đường cũ, không nói 'chưa rõ'",
       main._ctx_frame(_TraceChua(), 10)["ctx_path"] == "legacy")
 
-# Và phải NỐI vào cả ba khung trả lời người dùng thật sự đi qua. Đây là chỗ hay sót nhất.
-check("CANARY: cả ba nhánh engine đều gắn thông tin đường chạy",
-      _MAIN.count("**_ctx_frame(runtime_trace, _ctx_in)") == 3)
+# Và phải NỐI vào các khung trả lời người dùng thật sự đi qua. Đây là chỗ hay sót nhất.
+# Đếm CHÍNH XÁC bằng 3 là bản cũ, viết từ hồi chỉ có ba nhánh engine gắn nhãn. Nó vô tình
+# thành hàng rào chặn việc SỬA: gắn nhãn cho nhánh thứ tư là test đỏ, dù đó đúng là thứ phải
+# làm (chủ repo báo "có chỗ thì không hiện gì"). Bài kiểm đầy đủ - mọi gói `response` đều
+# phải mang nhãn - nằm ở test_duong_tat_bi_chan.
+check("CANARY: các nhánh engine đều gắn thông tin đường chạy",
+      _MAIN.count("**_ctx_frame(runtime_trace, _ctx_in)") >= 3)
 check("có cộng dồn token vào của lượt", _MAIN.count("_ctx_in +=") >= 3)
 check("giao diện có hàm vẽ dòng đó", "function _renderCtxLine(" in _APP and "msg-ctx" in _APP)
 # Định nghĩa hàm cũng chứa "_renderCtxLine(msgEl, data" nên phải soi lời GỌI có dấu chấm phẩy,


### PR DESCRIPTION
## Vấn đề

Chủ repo hỏi: sau này test ổn rồi thì có chọn mức Siêu tiết kiệm làm mặc định được không. Soi lại thì câu trả lời là "được, nhưng đổi xong sẽ không tới được máy nào cả".

Cái bẫy nằm ở cách Javis lưu cấu hình. `write_settings` ghi lại TOÀN BỘ config đã trộn, nên ngay lần đầu người dùng bấm bất cứ nút nào ở trang Cài đặt, giá trị mặc định của đúng ngày hôm đó bị đóng băng vào `settings.json`. `read_settings` lại trộn file ĐÈ LÊN mặc định. Hệ quả: về sau nâng `_DEFAULT` lên mức Tối ưu hay Siêu tiết kiệm thì chỉ máy cài mới tinh mới thấy, máy đang chạy thì không, và không có lỗi nào báo ra.

Đây đúng là con bệnh đã cắn `provider_kinds` hồi 0.12.4 (`_no_rong_pham_vi_bo_nao` sinh ra để vá), lần này rơi vào thứ quyết định mỗi lượt chat tốn bao nhiêu token.

Chỗ khó riêng của mức tiết kiệm: số `0` nằm trong file có HAI nghĩa ngược nhau - "người dùng đã cân nhắc và cố ý chọn Tắt", hoặc "chưa ai chọn gì, mặc định cũ đóng băng lại". Không phân biệt được hai cái đó thì phải chọn giữa hai cái sai: giẫm lên quyết định của người dùng, hoặc để mặc định mới không bao giờ tới nơi.

## Cách sửa

**Chữ ký.** Mọi endpoint đổi mức tiết kiệm (`/runtime/preset`, `/runtime/mode`, `/runtime/canary`) đóng dấu `context_runtime.preset_choice.source = "user"`. Có dấu thì không bản cập nhật nào đụng vào. Ký ở cả ba vì người vào phần Nâng cao chỉnh tay từng đường cũng là người có ý kiến riêng.

**Áp mặc định khi không có chữ ký.** `config._ap_muc_mac_dinh` chạy trong `read_settings`, nâng cấu hình lên ít nhất mức xuất xưởng của bản đang chạy. Từ đây, đổi mặc định là đổi đúng một dòng `PRESET_MAC_DINH` và nó tới được cả máy đã cài.

**Chỉ nâng, không bao giờ hạ.** Máy đang chạy mức cao hơn mặc định, kể cả do sửa tay `settings.json` (không để lại chữ ký nào), vẫn giữ nguyên. Không thứ gì người dùng đã bật bị bản cập nhật tắt đi. Mức không bật đường nào thì cũng không đụng tới `mode`, vì đó là công tắc dùng chung với các phase khác.

**Một nguồn sự thật.** Bảng "mức nào bật đường nào" chuyển từ `main.RUNTIME_PRESETS` sang `config.PRESET_DUONG`; `main` chỉ khoác nhãn và mô tả. Chỗ nâng mặc định nằm ở config mà config không import được main, nên chép hai bản thì tới lúc thêm một đường vào mức nào đó, chỗ nâng mặc định vẫn nâng theo bảng cũ.

**Nói ra cho người dùng.** Trang Tiết kiệm phân biệt "mức này do anh chọn" với "mức này chỉ là mặc định của bản đang chạy" - hai thứ trông y hệt nhau mà ý nghĩa ngược nhau, vì cái sau sẽ đi lên theo bản cập nhật.

## Phạm vi

Bản này **chưa đổi mặc định của ai**: `PRESET_MAC_DINH` vẫn là `"off"`. Nó chỉ dựng sẵn cơ chế để lần nâng sau đi được tới nơi.

Một chỗ mơ hồ còn lại, ghi ra cho minh bạch: máy nào từng cố ý chọn Tắt TRƯỚC bản này thì không để lại chữ ký nào, nên tới ngày nâng mặc định sẽ được nâng theo. Đổi lại, luật chỉ-nâng đảm bảo không có gì đang bật bị tắt đi, và bấm một mức một lần sau khi cập nhật là ghim vĩnh viễn.

## Kiểm chứng

`tests/python/test_muc_mac_dinh.py` giả lập việc nâng mặc định (đổi `PRESET_MAC_DINH` rồi đọc lại) thay vì chờ tới ngày thật sự nâng - một cơ chế di trú chỉ chạy đúng một lần trong đời mà không có test thì tới hôm dùng mới biết nó hỏng.

Chín đột biến, bắt hết:

| # | Đột biến | Kết quả |
|---|---|---|
| 1 | bỏ bước áp mặc định trong `read_settings` | BẮT |
| 2 | phớt lờ chữ ký của người dùng | BẮT |
| 3 | cho phép HẠ chứ không chỉ nâng | BẮT |
| 4 | quên nâng công tắc trùm | BẮT |
| 5 | `/runtime/preset` không ký tên | BẮT |
| 6 | `/runtime/mode` không ký tên | BẮT |
| 7 | `/runtime/canary` không ký tên | BẮT |
| 8 | `main` chép lại bảng mức của riêng nó | BẮT |
| 9 | mức Tắt vẫn thò tay vào công tắc trùm | BẮT |

Hai con (3 và 6) ban đầu lọt lưới, cả hai đều do test viết hớ chứ không phải mã sai: con 3 vì ba mức hiện tại đều bật 100% nên không mức nào hạ được ai (nay gọi thẳng hàm với một mức giả bật một phần), con 6 vì chữ ký của endpoint trước còn nằm đó (nay mỗi endpoint đo trên nền sạch).

151/151 test Python + JS xanh.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzD2ScDSEcDuvVGsxy5wLR)_