### PR TITLE
fix: mục Token API nằm ở trang Tài khoản, không phải Cài đặt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Lịch sử phiên bản Javis OS. Bản mới nhất ở trên cùng. Xem ngay 
 - **Javis biết mình đang nói qua terminal nên trả lời khác.** Kênh `cli` có khối ngữ cảnh và hợp đồng đầu ra riêng: không bảng markdown, không nhúng ảnh, không link markdown, đường dẫn file in TUYỆT ĐỐI để copy chạy được luôn.
 - **Luật Unix, để ghép được vào script.** Câu trả lời ra stdout, mọi thứ khác (tiến độ, tên tool, lỗi) ra stderr. Nên `javis "tóm tắt tuần này" > bao-cao.md` cho ra file sạch. Lỗi thì thoát khác 0 và không in gì ra stdout, nên `&&` trong script hành xử đúng. Có test canh đúng MỘT chỗ trong cả gói được ghi stdout.
 - **Nối được nhiều Javis cùng lúc**: một hồ sơ cho máy nhà, một cho VPS, đổi bằng `--profile`. Cấu hình ở `~/.javis/config.json` quyền `600`, và bốn biến môi trường (`JAVIS_URL`, `JAVIS_TOKEN`, `JAVIS_BRAIN`, `JAVIS_PROFILE`) đè lên file cho CI/Docker.
-- **Trang Cài đặt có mục Token API.** Tạo token, chọn phạm vi, xem lần dùng cuối của từng cái, thu hồi. Chuỗi thô hiện đúng MỘT lần kèm sẵn câu lệnh `javis login` để dán sang máy kia.
+- **Trang Tài khoản có mục Token API.** Tạo token, chọn phạm vi, xem lần dùng cuối của từng cái, thu hồi. Chuỗi thô hiện đúng MỘT lần kèm sẵn câu lệnh `javis login` để dán sang máy kia.
 ### Bảo mật
 - **Không có token nào sẵn.** Chưa ai bấm tạo thì không token nào tồn tại, và không cửa nào vào ngoài trình duyệt. Đây là điểm quan trọng nhất của cả tính năng: mở cổng mới ra Internet phải là một hành động CÓ Ý THỨC, không phải mặc định.
 - **Hai mức phạm vi.** `chat` đi theo danh sách TRẮNG (`/chat`, `/version`, `/health`, `/sessions`); `full` ngang session trình duyệt. Chọn chiều trắng chứ không chiều đen, vì danh sách đen nghĩa là mỗi endpoint mới thêm vào server tự động phơi ra cho token hẹp.

--- a/cli/javis_cli/client.py
+++ b/cli/javis_cli/client.py
@@ -32,7 +32,7 @@ class Client:
         if r.status_code == 401:
             raise LoiJavis(
                 "Máy chủ từ chối: token thiếu hoặc đã bị thu hồi.\n"
-                "Tạo token mới ở dashboard (Cài đặt > Token API) rồi chạy lại `javis login`.")
+                "Tạo token mới ở dashboard (Tài khoản > Token API) rồi chạy lại `javis login`.")
         if r.status_code == 403:
             raise LoiJavis("Máy chủ từ chối: token này không có quyền cho lệnh đó.")
         if r.status_code == 429:

--- a/cli/javis_cli/commands.py
+++ b/cli/javis_cli/commands.py
@@ -103,7 +103,7 @@ def login(args) -> int:
         url = "https://" + url
     token = args.token or ""
     if not token:
-        r.tieu_de("Tạo token ở dashboard: Cài đặt > Token API, rồi dán vào đây.")
+        r.tieu_de("Tạo token ở dashboard: Tài khoản > Token API, rồi dán vào đây.")
         try:
             token = input("Token: ").strip()
         except (EOFError, KeyboardInterrupt):

--- a/dashboard/console.js
+++ b/dashboard/console.js
@@ -140,7 +140,7 @@
     mcp:         { icon: VIEW_ICON.mcp, label: "Kết nối", sub: "Nguồn dữ liệu & công cụ" },
     plugins:     { icon: VIEW_ICON.plugins, label: "Plugins", sub: "Tool/hook native cho mọi engine" },
     logs:        { icon: VIEW_ICON.logs, label: "Nhật ký cập nhật", sub: "Phiên bản & tính năng mới" },
-    account:     { icon: VIEW_ICON.account, label: "Tài khoản", sub: "Đăng nhập & workspace" },
+    account:     { icon: VIEW_ICON.account, label: "Tài khoản", sub: "Đăng nhập, workspace, token API" },
     usage:       { icon: VIEW_ICON.usage, label: "Mức dùng", sub: "Token & chi phí theo ngày, theo nhà cung cấp" },
     runtime:     { icon: VIEW_ICON.runtime, label: "Tiết kiệm", sub: "Xem Javis đang tốn bao nhiêu token mỗi lượt, và chọn mức tiết kiệm" },
   };
@@ -4441,7 +4441,7 @@
           <div class="settings-links">
             <button data-settings-go="models"><span>◈</span><b>Models</b><small>Model và nhà cung cấp</small></button>
             <button data-settings-go="channels"><span>${ic("send")}</span><b>Kênh</b><small>Telegram và kết nối chat</small></button>
-            <button data-settings-go="account"><span>${ic("circle-user")}</span><b>Tài khoản</b><small>Đăng nhập và workspace</small></button>
+            <button data-settings-go="account"><span>${ic("circle-user")}</span><b>Tài khoản</b><small>Đăng nhập, workspace, token API cho CLI</small></button>
             <button data-settings-go="logs"><span>${ic("scroll-text")}</span><b>Cập nhật</b><small>Phiên bản và nhật ký mới</small></button>
           </div>
         </div>

--- a/docs/14-bao-mat-tai-khoan.md
+++ b/docs/14-bao-mat-tai-khoan.md
@@ -17,12 +17,13 @@ Javis xử lý việc này theo 6 lớp:
 
 ## Mở ở đâu trong Javis
 
-Mọi thao tác tài khoản nằm ở mục **Tài khoản** trong nhóm **Hệ thống** trên thanh nav bên trái (phụ đề "Đăng nhập & workspace"). Từ trang **Cài đặt** cũng có lối tắt tới đây; không có form tài khoản trùng lặp ở nơi khác.
+Mọi thao tác tài khoản nằm ở mục **Tài khoản** trong nhóm **Hệ thống** trên thanh nav bên trái (phụ đề "Đăng nhập, workspace, token API"). Từ trang **Cài đặt** cũng có lối tắt tới đây; không có form tài khoản trùng lặp ở nơi khác.
 
-Trang **Tài khoản** có 2 khối:
+Trang **Tài khoản** có 3 khối:
 
 - **Workspace**: đổi tên workspace hiển thị.
 - **Tài khoản đăng nhập**: đặt mật khẩu, đăng xuất, tắt đăng nhập.
+- **Token API (cho CLI)**: tạo và thu hồi token để [Javis CLI](24-cli-terminal.md) hay script gọi được Javis. Nằm cùng trang vì token cũng là một cách đăng nhập, chỉ khác là dành cho máy chứ không cho trình duyệt.
 
 ## Khi nào Javis bắt buộc đăng nhập
 
@@ -151,7 +152,7 @@ Khi nào bạn cần đụng tới: chạy Javis sau một reverse proxy với t
 
 ## Token API - cửa cho CLI và script
 
-Cookie đăng nhập chỉ hợp với trình duyệt. Khi bạn muốn [Javis CLI](24-cli-terminal.md) hay một script gọi được Javis, cần một credential khác: **token API**, tạo ở **Cài đặt > Token API (cho CLI)**.
+Cookie đăng nhập chỉ hợp với trình duyệt. Khi bạn muốn [Javis CLI](24-cli-terminal.md) hay một script gọi được Javis, cần một credential khác: **token API**, tạo ở **Tài khoản > Token API (cho CLI)** (nhóm Hệ thống, cùng trang với mật khẩu đăng nhập).
 
 Điểm quan trọng nhất: **không có token nào sẵn**. Chưa tự tay bấm tạo thì không token nào tồn tại, và không cửa nào vào ngoài trình duyệt. Mở thêm một cổng ra Internet phải là một hành động có ý thức.
 

--- a/docs/17-khac-phuc-su-co.md
+++ b/docs/17-khac-phuc-su-co.md
@@ -29,8 +29,8 @@ Rất nhiều lỗi biến mất sau một trong hai việc này, nên thử tr�
 | Ảnh trong hội thoại cũ hiện ô xám **Ảnh đã hết hạn** | Đúng thiết kế: `attachments/` và `inbox/` là vùng cache, file quá 30 ngày (hoặc khi vượt trần 300MB) bị dọn. Xem mục "Ảnh và file cũ biến mất" bên dưới để biết cách giữ lại hoặc tắt hẳn. |
 | Voice / micro không bật được | Trình duyệt chỉ cấp quyền micro trên **HTTPS** (hoặc localhost). Mở qua `http://<ip>:7777` sẽ luôn bị chặn. Dùng URL `https://` (Hostinger `*.hstgr.cloud`, Cloudflare Tunnel, hoặc tên miền riêng có SSL). Xem [Thương hiệu & tên miền riêng](15-thuong-hieu-ten-mien.md). |
 | Cập nhật trong app xong mà **phiên bản không đổi** | Đợi thêm; nếu vẫn báo bản cũ, kiểm tra log cập nhật: `update.log` trong thư mục state (`server/update.log` khi chạy local, `/data/state/update.log` trên Docker), hoặc `docker compose logs`. |
-| **`javis` báo 401** hoặc "token không hợp lệ" | Token sai hoặc đã bị thu hồi. Tạo cái mới ở **Cài đặt > Token API** rồi `javis login <địa-chỉ>` lại. Xem [Javis CLI](24-cli-terminal.md). |
-| **`javis task add` / `javis brain ls` báo 403** | Token của bạn là loại **chỉ chat**. Những lệnh này cần token **toàn quyền** - tạo thêm một cái ở Cài đặt > Token API. |
+| **`javis` báo 401** hoặc "token không hợp lệ" | Token sai hoặc đã bị thu hồi. Tạo cái mới ở **Tài khoản > Token API** rồi `javis login <địa-chỉ>` lại. Xem [Javis CLI](24-cli-terminal.md). |
+| **`javis task add` / `javis brain ls` báo 403** | Token của bạn là loại **chỉ chat**. Những lệnh này cần token **toàn quyền** - tạo thêm một cái ở Tài khoản > Token API. |
 | **`javis up` báo không thấy bản cài Javis** | Đúng như nó nói: gói CLI KHÔNG chứa server bên trong. Đặt `JAVIS_HOME` trỏ tới thư mục Javis, chạy lệnh từ trong thư mục đó, hoặc `javis login <địa-chỉ>` để nối tới một Javis đang chạy nơi khác. |
 
 Các mục dưới đây giải thích chi tiết hơn từng dòng trong bảng.

--- a/docs/24-cli-terminal.md
+++ b/docs/24-cli-terminal.md
@@ -33,7 +33,7 @@ Xong thì có lệnh `javis`. Kiểm tra: `javis --help`.
 
 Máy chủ Javis không nhận lệnh từ bên ngoài nếu chưa có token. **Không có token nào sẵn** - chưa tự tay tạo thì cửa này đóng.
 
-1. Mở dashboard Javis, vào **Cài đặt** (nhóm Hệ thống) rồi kéo tới mục **Token API (cho CLI)**.
+1. Mở dashboard Javis, vào **Tài khoản** (nhóm **Hệ thống** ở cuối thanh bên trái) rồi kéo tới mục **Token API (cho CLI)**. Cùng trang với mật khẩu đăng nhập, vì token cũng là một cách đăng nhập.
 2. Đặt tên dễ nhớ, ví dụ "laptop của anh" - sau này thu hồi thì biết đang thu hồi cái nào.
 3. Chọn phạm vi:
    - **Chỉ chat** - vào được `/chat`, `/version`, `/health`, `/sessions`. Đủ để hỏi đáp và xem lịch sử. Chọn cái này nếu chỉ định hỏi han.
@@ -154,7 +154,7 @@ Không tìm thấy bản cài thì nó nói thẳng: **`javis up` không chứa 
 
 ## Quản lý token
 
-Vào **Cài đặt > Token API** trong dashboard. Danh sách hiện tên, 12 ký tự đầu, phạm vi, và **lần dùng cuối** - nếu thấy một token bạn không nhớ đang được dùng đều đặn thì đó là dấu hiệu cần thu hồi ngay.
+Vào **Tài khoản > Token API** trong dashboard. Danh sách hiện tên, 12 ký tự đầu, phạm vi, và **lần dùng cuối** - nếu thấy một token bạn không nhớ đang được dùng đều đặn thì đó là dấu hiệu cần thu hồi ngay.
 
 Bấm **Thu hồi** là token chết lập tức, máy nào đang dùng nó mất kết nối ngay và không hoàn tác được.
 
@@ -169,7 +169,7 @@ Vài điều đáng biết về cách Javis giữ token:
 
 **"Chưa nối tới Javis nào"** - chạy `javis login <địa-chỉ>` trước.
 
-**Báo 401 hoặc "token không hợp lệ"** - token sai, hoặc đã bị thu hồi. Tạo cái mới ở Cài đặt > Token API rồi `javis login` lại.
+**Báo 401 hoặc "token không hợp lệ"** - token sai, hoặc đã bị thu hồi. Tạo cái mới ở Tài khoản > Token API rồi `javis login` lại.
 
 **Báo 403 khi gõ `javis task add` hay `javis brain ls`** - token của bạn là loại **chỉ chat**. Tạo một token **toàn quyền** cho những lệnh này.
 

--- a/tests/js/test_token_api_ui.js
+++ b/tests/js/test_token_api_ui.js
@@ -85,6 +85,33 @@ check("khối token mới có kiểu riêng để không lướt qua mất", /\.
 check("bản thô cho bôi đen cả cụm", /user-select: all/.test(CSS));
 check("danh sách token có kiểu", /\.tk-row \{/.test(CSS));
 
+// ============================================================
+// 6. Tài liệu và CLI phải chỉ ĐÚNG trang
+// ============================================================
+// Lỗi thật, bắt được ngay ngày phát hành: cả tài liệu lẫn lời nhắc trong `javis login` đều ghi
+// "Cài đặt > Token API", trong khi mục đó do renderAccount() vẽ, tức là trang **Tài khoản**.
+// Người dùng vào Cài đặt, không thấy gì, và kết luận tính năng chưa có. Không một dòng lỗi nào
+// xuất hiện - đây đúng loại sai mà chỉ test mới bắt được, còn người thì đọc mãi vẫn trượt.
+check("mục Token API do renderAccount vẽ (tức là trang Tài khoản)",
+  CON.indexOf("async function renderAccount(") < CON.indexOf("<h3>Token API (cho CLI)</h3>")
+  && CON.indexOf("<h3>Token API (cho CLI)</h3>") < CON.indexOf("async function renderTokens("));
+
+const NOI = [
+  ["cli/javis_cli/client.py", "thông báo 401 của CLI"],
+  ["cli/javis_cli/commands.py", "lời nhắc lúc javis login"],
+  ["docs/24-cli-terminal.md", "tài liệu CLI"],
+  ["docs/14-bao-mat-tai-khoan.md", "tài liệu bảo mật"],
+  ["docs/17-khac-phuc-su-co.md", "tài liệu sự cố"],
+];
+for (const [f, ten] of NOI) {
+  const t = fs.readFileSync(path.join(ROOT, f), "utf8");
+  check(`CANARY: ${ten} không chỉ nhầm sang trang Cài đặt`,
+    !/Cài đặt\s*(>|&gt;)\s*Token API/.test(t));
+}
+// Và phải chỉ ĐÚNG chỗ, chứ không phải chỉ "không sai".
+const DOC = fs.readFileSync(path.join(ROOT, "docs", "24-cli-terminal.md"), "utf8");
+check("tài liệu CLI chỉ đúng trang Tài khoản", /Tài khoản\s*(>|&gt;)?\s*.{0,40}Token API|\*\*Tài khoản\*\*/.test(DOC));
+
 console.log("");
 if (fails.length) { console.log("THẤT BẠI " + fails.length + ": " + fails.join(", ")); process.exit(1); }
 console.log("OK - test_token_api_ui: tất cả pass");


### PR DESCRIPTION
Chủ repo hỏi *"cái này không bật trên trình duyệt của Javis được nhỉ"* - soát lại thì phát hiện tài liệu và CLI đều chỉ sai chỗ.

Mục Token API do `renderAccount()` vẽ, tức là trang **Tài khoản**. Nhưng năm nơi khác nhau đều ghi "Cài đặt > Token API". Người dùng vào Cài đặt, không thấy gì, kết luận tính năng chưa lên.

Loại sai này đáng nói riêng: không hỏng chức năng nào, không sinh một dòng lỗi nào, bộ test cũ xanh hết. Chỉ người dùng thật đi tìm mới lộ ra.

## Sửa

- Hai chỗ trong CLI: thông báo 401 (`client.py`) và lời nhắc lúc `javis login` (`commands.py`).
- Ba tài liệu: `24-cli-terminal`, `14-bao-mat-tai-khoan`, `17-khac-phuc-su-co`.
- Dòng CHANGELOG 0.17.0.

## Chỉ đường cho người đi nhầm

Sửa tên trang thôi thì chưa đủ - ai đã quen nghĩ "cài đặt" vẫn sẽ vào Cài đặt trước.

- Phụ đề mục **Tài khoản** trên thanh nav: `Đăng nhập & workspace` → `Đăng nhập, workspace, token API`.
- Nút lối tắt bên trang Cài đặt cũng ghi rõ có token API cho CLI.
- Tài liệu bảo mật: trang Tài khoản nay mô tả đủ **3 khối** thay vì 2.

## Canary chặn tái diễn

`test_token_api_ui.js` nay kiểm mục Token API do **hàm nào** vẽ (`renderAccount` chứ không phải `renderSettings`), rồi đối chiếu với năm nơi có nhắc tên trang. Đã thử cố tình ghi sai lại một lần để xác nhận nó đỏ đúng chỗ, rồi khôi phục.

**158/158 test xanh.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzD2ScDSEcDuvVGsxy5wLR)_