### PR TITLE
fix: installer dò Python >= 3.10, không tin `python3` trần

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,18 +18,52 @@ cd "$APP_DIR"
 
 SUDO=""; [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && SUDO="sudo"
 
-# --- 1. python3 + venv + pip ---
-log "Checking Python 3..."
-if ! command -v python3 >/dev/null 2>&1; then
-  log "Installing python3..."
+# --- 1. python3 >= 3.10 + venv + pip ---
+# HARD FLOOR 3.10: uvicorn pinned in requirements.txt needs >=3.10 (every release from
+# 0.40 up dropped 3.9). Do NOT trust a bare `python3` here - macOS ships /usr/bin/python3
+# = 3.9 and it sits AHEAD of Homebrew in PATH, so the old code happily printed
+# "OK Python 3.9.6" and then died 40 lines later with the useless pip error
+# "No matching distribution found for uvicorn==0.51.0". Probe for a real interpreter.
+PY_MIN="3.10"
+py_ok() { "$1" -c 'import sys; sys.exit(0 if sys.version_info[:2] >= (3, 10) else 1)' >/dev/null 2>&1; }
+
+PYTHON_BIN=""
+find_python() {
+  local c d
+  # NOT newest-first. requirements.txt pins hard (fastapi 0.115.0, cryptography, uvloop,
+  # watchfiles, pydantic-core - all need compiled wheels), so prefer the versions with the
+  # widest wheel coverage and fall back to a bleeding-edge interpreter only if nothing else
+  # exists: on a brand-new 3.x, pip finds no wheel and tries to BUILD from source, which
+  # fails on any machine without a compiler toolchain. 3.11/3.12 is the verified sweet spot.
+  for c in python3.12 python3.11 python3.13 python3.10 python3 python3.14 python; do
+    if py_ok "$c"; then PYTHON_BIN="$(command -v "$c")"; return 0; fi
+  done
+  # Homebrew python is keg-only on some setups (never linked into PATH); look directly.
+  # Same preference order, explicit rather than a glob (a glob sorts 3.10 ahead of 3.12).
+  for d in /opt/homebrew/bin /usr/local/bin; do
+    for c in python3.12 python3.11 python3.13 python3.10 python3.14; do
+      if py_ok "$d/$c"; then PYTHON_BIN="$d/$c"; return 0; fi
+    done
+  done
+  return 1
+}
+
+log "Checking Python >= $PY_MIN..."
+if ! find_python; then
+  log "No Python >= $PY_MIN found - installing..."
   if command -v apt-get >/dev/null 2>&1; then
     $SUDO apt-get update -qq && $SUDO apt-get install -y python3 python3-venv python3-pip
   elif command -v dnf >/dev/null 2>&1; then $SUDO dnf install -y python3 python3-pip
   elif command -v brew >/dev/null 2>&1; then brew install python
-  else err "Install python3 manually then re-run."; exit 1; fi
+  else err "Install Python $PY_MIN or newer manually, then re-run."; exit 1; fi
+  find_python || {
+    err "Still no Python >= $PY_MIN after install (found: $(python3 --version 2>&1 || echo none))."
+    err "Install it manually (macOS: brew install python), then re-run."
+    exit 1
+  }
 fi
-python3 -m venv --help >/dev/null 2>&1 || { command -v apt-get >/dev/null 2>&1 && $SUDO apt-get install -y python3-venv; }
-ok "$(python3 --version)"
+"$PYTHON_BIN" -m venv --help >/dev/null 2>&1 || { command -v apt-get >/dev/null 2>&1 && $SUDO apt-get install -y python3-venv; }
+ok "$("$PYTHON_BIN" --version) ($PYTHON_BIN)"
 
 # --- 2. system deps: git, ripgrep, ffmpeg (best-effort) ---
 log "Installing system deps (git, ripgrep, ffmpeg)..."
@@ -75,7 +109,13 @@ ok "Claude CLI $(claude --version 2>/dev/null || echo installed)"
 
 # --- 5. venv + python deps ---
 log "Creating virtualenv (.venv)..."
-[ -d .venv ] || python3 -m venv .venv
+# A .venv left over from a failed run can be built on 3.9 - reusing it reproduces the
+# exact uvicorn resolve error the probe above exists to prevent. Rebuild instead.
+if [ -d .venv ] && ! py_ok ./.venv/bin/python; then
+  warn ".venv runs $(./.venv/bin/python --version 2>&1 || echo 'an unusable Python') - rebuilding with $PYTHON_BIN"
+  rm -rf .venv
+fi
+[ -d .venv ] || "$PYTHON_BIN" -m venv .venv
 ./.venv/bin/pip install --upgrade pip -q
 ./.venv/bin/pip install -r requirements.txt -q
 ok "Python deps installed"


### PR DESCRIPTION
## Vấn đề

`./install.sh` gãy ở bước cài deps trên mọi máy macOS sạch. Log thật:

```
-> Checking Python 3...
OK Python 3.9.6
...
-> Creating virtualenv (.venv)...
ERROR: Ignored the following versions that require a different python version:
       0.129.0 Requires-Python >=3.10; ... 0.52.1 Requires-Python >=3.10
ERROR: Could not find a version that satisfies the requirement uvicorn==0.51.0
ERROR: No matching distribution found for uvicorn==0.51.0
```

Nguyên nhân: macOS ship sẵn `/usr/bin/python3` = **3.9**, và nó nằm **trước** Homebrew trong `PATH`. Bước 1 chỉ hỏi `command -v python3` — có là được, không quan tâm phiên bản — nên in `OK Python 3.9.6` rồi chạy tiếp, để chết ở bước 5.

Còn pin `uvicorn[standard]==0.51.0` trong `requirements.txt` thì cần Python >= 3.10 (mọi bản uvicorn từ 0.40 trở lên đều bỏ 3.9). pip lọc sạch danh sách rồi báo lỗi như thể **tên gói sai**, khiến người cài đi tìm nhầm hướng — dễ tưởng repo pin sai version.

## Sửa gì

**1. Dò interpreter thay vì tin `python3` trần**

`find_python()` hỏi thẳng từng ứng viên bằng `sys.version_info`, và **kiểm lại sau khi cài** — code cũ cài xong là coi như xong, không verify.

Thứ tự ưu tiên cố ý **không phải mới-nhất-trước**: `3.12 → 3.11 → 3.13 → 3.10 → python3 → 3.14`. Lý do: `requirements.txt` pin chặt và kéo theo `cryptography`, `uvloop`, `watchfiles`, `pydantic-core` — đều cần wheel biên dịch sẵn. Trên interpreter quá mới pip không thấy wheel nên chuyển sang build from source, hỏng ngay trên máy không có toolchain. Nhảy thẳng lên bản mới nhất chỉ đổi lỗi này lấy lỗi khác khó hiểu hơn.

Có thêm nhánh dò trực tiếp `/opt/homebrew/bin` và `/usr/local/bin` cho trường hợp Homebrew python keg-only (không link vào `PATH`).

**2. Không tái dùng `.venv` dựng trên Python cũ**

Dòng cũ `[ -d .venv ] || python3 -m venv .venv` có bẫy: lần chạy đầu hỏng để lại `.venv` trên 3.9, lần chạy sau thấy thư mục tồn tại nên bỏ qua bước tạo và **lại đâm vào đúng lỗi uvicorn**. Chạy lại installer không tự thoát được — phải tự tay `rm -rf .venv` mới xong. Giờ phát hiện < 3.10 thì cảnh báo và dựng lại.

## Đã kiểm

macOS 15 (Darwin 25.5), máy có sẵn cả 3.9.6, 3.11.15 và 3.14.6:

- `bash -n install.sh` sạch
- probe chọn 3.11.15, từ chối đúng `/usr/bin/python3` (3.9.6) và binary không tồn tại
- probe **không** vớ 3.14.6 của Homebrew — đúng ý thiết kế ở trên
- guard `.venv`: dựng venv 3.9 thật rồi chạy → in `!! .venv runs Python 3.9.6 - rebuilding...` và dựng lại thành 3.11.15
- cài đủ `requirements.txt` không lỗi, đúng cặp pin mà comment trong file dặn (fastapi 0.115.0 + starlette 0.38.6 + uvicorn 0.51.0)
- server lên `http://127.0.0.1:7777`, trả HTTP 200

Không đụng `requirements.txt` — pin giữ nguyên, chỉ sửa chỗ chọn interpreter.

Chỉ thay đổi nội dung `install.sh`, không đổi file mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
