### PR TITLE
Fix Vietnamese IME Enter residue in chat

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1581,7 +1581,14 @@ chatInput.addEventListener("input", () => {
   const _cap = document.body.classList.contains("on-chat") ? 220 : 90;
   chatInput.style.height = Math.min(chatInput.scrollHeight, _cap) + "px";
 });
+// Bộ gõ tiếng Việt/IME có thể phát keydown Enter trước compositionend. Nếu gửi và xoá
+// textarea ở thời điểm đó, trình duyệt sẽ chốt phần chữ đang ghép vào ô vừa xoá, làm sót
+// lại ký tự hoặc từ cuối. Giữ cờ riêng cho các trình duyệt báo isComposing không ổn định.
+let chatInputComposing = false;
+chatInput.addEventListener("compositionstart", () => { chatInputComposing = true; });
+chatInput.addEventListener("compositionend", () => { chatInputComposing = false; });
 chatInput.addEventListener("keydown", (e) => {
+  if (chatInputComposing || e.isComposing || e.keyCode === 229) return;
   if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); }
 });
 sendBtn.addEventListener("click", () => sendMessage());

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -678,7 +678,7 @@
   <script src="/static/chat-ask.js?v=1"></script>
   <script src="/static/chat-slash.js?v=1"></script>
   <script src="/static/chat-acts.js?v=1"></script>
-  <script src="/static/app.js?v=79"></script>
+  <script src="/static/app.js?v=80"></script>
   <script src="/static/model-picker.js?v=3"></script>
   <script src="/static/branding.js?v=7"></script>
   <script src="/static/quick-settings.js?v=4"></script>

--- a/tests/js/test_chat_ime_enter.js
+++ b/tests/js/test_chat_ime_enter.js
@@ -1,0 +1,28 @@
+/* Hồi quy: Enter khi bộ gõ tiếng Việt/IME còn composition không được gửi tin. */
+const fs = require("fs");
+const path = require("path");
+
+const root = path.join(__dirname, "..", "..");
+const app = fs.readFileSync(path.join(root, "dashboard", "app.js"), "utf8");
+const html = fs.readFileSync(path.join(root, "dashboard", "index.html"), "utf8");
+
+let fails = [];
+function check(name, cond) {
+  console.log((cond ? "ok   " : "FAIL ") + name);
+  if (!cond) fails.push(name);
+}
+
+check("theo dõi compositionstart", /chatInput\.addEventListener\("compositionstart"/.test(app));
+check("theo dõi compositionend", /chatInput\.addEventListener\("compositionend"/.test(app));
+check("keydown chặn cờ composition riêng", /if \(chatInputComposing \|\|/.test(app));
+check("keydown chặn isComposing chuẩn", /\|\| e\.isComposing \|\|/.test(app));
+check("keydown có dự phòng IME keyCode 229", /e\.keyCode === 229\) return/.test(app));
+check("Enter thường vẫn gửi tin", /e\.key === "Enter" && !e\.shiftKey/.test(app));
+const appVersion = Number((html.match(/app\.js\?v=(\d+)/) || [])[1] || 0);
+check("app.js đã bump cache", appVersion >= 80);
+
+if (fails.length) {
+  console.log("\nFAIL - test_chat_ime_enter: " + fails.length + " lỗi: " + fails.join(", "));
+  process.exit(1);
+}
+console.log("\nOK - test_chat_ime_enter: tất cả pass");


### PR DESCRIPTION
## Tóm tắt\n- không gửi tin khi bộ gõ IME còn đang ghép chữ\n- dự phòng cho trình duyệt dùng keyCode 229\n- thêm test hồi quy và bump cache app.js\n\n## Kiểm tra\n- node --check dashboard/app.js\n- node tests/js/test_chat_ime_enter.js\n- node tests/js/test_chat_slash.js\n- node tests/js/test_chat_ask.js\n- git diff --check