### PR TITLE
Thêm quy trình đóng góp cho người ngoài: CONTRIBUTING + PR template + CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Tự gắn người review cho MỌI Pull Request, dù không bật "Require review" trong branch
+# protection. Xem CONTRIBUTING.md để biết quy trình đóng góp đầy đủ.
+* @blogminhquy

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Tóm tắt
+
+<!-- Vì sao cần thay đổi này? Vấn đề gì đang gặp, hoặc tính năng gì đang thiếu. -->
+
+## Thay đổi chính
+
+-
+
+## Test
+
+<!-- Đã chạy `python tests/run.py` chưa? Có test thủ công gì thêm không (vd thử trên UI)? -->
+
+- [ ] `python tests/run.py` chạy xanh
+- [ ]
+
+## Ảnh hưởng
+
+<!-- File/tính năng nào bị đụng tới? Có rủi ro phá tính năng khác không? -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Đóng góp cho Javis OS
+
+Cảm ơn bạn đã muốn đóng góp. Repo này nhận Pull Request từ **fork** - bạn không cần quyền
+ghi trực tiếp, chỉ cần fork về tài khoản của mình, code, rồi mở PR nhắm vào nhánh `main`.
+
+## Quy trình
+
+1. **Fork** repo này, clone bản fork về máy.
+2. Tạo nhánh mới đặt tên gợi nhớ việc đang làm (vd `fix-zoom-mobile`, `them-mcp-notion`).
+3. Code, rồi tự chạy test trước khi mở PR (xem mục Test bên dưới) - PR chưa chạy test
+   local dễ vướng lỗi vặt mà CI mới bắt được.
+4. Mở PR nhắm vào `main` của repo gốc (`blogminhquy/javis-os`), mô tả rõ **vì sao** cần
+   thay đổi này, không chỉ **cái gì** đã đổi (cái gì thì đọc diff là thấy).
+5. CI (GitHub Actions) tự chạy. PR xanh + được duyệt mới merge - không có merge tự động,
+   người giữ repo sẽ tự xem qua từng PR.
+
+## Chạy test trước khi mở PR
+
+```bash
+pip install -r requirements.txt
+python tests/run.py          # chạy hết (Python + JS)
+python tests/run.py --py     # chỉ Python
+python tests/run.py --js     # chỉ JS
+```
+
+Script tự tìm `.venv` nếu có, chạy được từ bất kỳ thư mục nào trong repo.
+
+## Quy ước code
+
+Dự án theo các quy ước ghi trong `CLAUDE.md` ở gốc repo (dùng cho cả người lẫn AI agent
+làm việc trên repo) - đáng đọc qua trước khi sửa nhiều, đặc biệt các mục:
+
+- Không thêm tính năng/refactor ngoài phạm vi PR đang làm.
+- Comment chỉ viết khi giải thích **vì sao** (constraint ẩn, workaround), không lặp lại
+  cái code đã nói (**cái gì**).
+- `CHANGELOG.md` viết cho người đọc trên điện thoại: vài gạch đầu dòng, nói người dùng
+  **thấy gì khác**, không kể tên hàm/đường dẫn file (chi tiết kỹ thuật để trong PR).
+- Không dùng ký tự em dash (—); thay bằng dấu gạch nối `-`.
+
+## Báo lỗi / đề xuất tính năng trước khi code
+
+Với thay đổi nhỏ, cứ mở PR thẳng. Với tính năng lớn hoặc đổi kiến trúc, nên mở **Issue**
+mô tả trước để bàn hướng làm - tránh trường hợp code xong mà hướng không khớp với dự án.
+
+## Vấn đề bảo mật
+
+Đừng báo lỗi bảo mật qua Issue công khai. Liên hệ trực tiếp với người giữ repo.

--- a/README.en.md
+++ b/README.en.md
@@ -318,6 +318,20 @@ javis-os/
 
 ---
 
+## ☕ Support Javis OS
+
+Javis OS is open-source and free to use, and it's still just one person (me) writing the code and covering the test server bills every day. If Javis has been useful for your work or your life, a small donation buys me more time to fix bugs and ship new features instead of worrying about server costs.
+
+No obligation, no perks attached - just a thank-you sent as money to someone quietly coding at night.
+
+- 🏦 **MB Bank** (Vietnam): `6636966369`
+- 📱 **MoMo wallet** (Vietnam): `0372752740`
+- 🌍 **PayPal**: [paypal.me/quy01](https://paypal.me/quy01)
+
+Can't donate? No worries - using Javis, sending feedback, or opening a Pull Request counts as support too.
+
+---
+
 <div align="center">
 
 Made with ☕ by **[Minh Quý](https://minhquy.vn)** · Repo: `github.com/blogminhquy/javis-os`

--- a/README.md
+++ b/README.md
@@ -315,6 +315,20 @@ javis-os/
 
 ---
 
+## ☕ Ủng hộ Javis OS
+
+Javis OS mã nguồn mở, dùng miễn phí, và mình vẫn đang một mình vừa code vừa gánh chi phí server chạy thử mỗi ngày. Nếu Javis đang giúp được gì cho công việc hay cuộc sống của bạn, một chút ủng hộ sẽ giúp mình có thêm thời gian ngồi sửa bug, viết tính năng mới, thay vì lo tiền server.
+
+Không bắt buộc, không đổi lấy quyền lợi gì cả - đơn giản là một lời cảm ơn gửi bằng tiền cho người đang âm thầm code buổi tối.
+
+- 🏦 **MB Bank**: `6636966369`
+- 📱 **Ví MoMo**: `0372752740`
+- 🌍 **PayPal**: [paypal.me/quy01](https://paypal.me/quy01)
+
+Không tiện donate cũng không sao - dùng Javis, góp ý, hay gửi một Pull Request cũng đã là ủng hộ rồi.
+
+---
+
 <div align="center">
 
 Made with ☕ by **[Minh Quý](https://minhquy.vn)** · Repo: `github.com/blogminhquy/javis-os`


### PR DESCRIPTION
## Summary
Repo `blogminhquy/javis-os` đã ở chế độ **public**, nên ai cũng fork + mở Pull Request được ngay từ bây giờ - không cần đổi visibility. PR này formalize quy trình nhận đóng góp + thêm mục ủng hộ vào README:

- **`CONTRIBUTING.md`** (mới): hướng dẫn fork → nhánh → chạy test local → mở PR nhắm `main`; nhắc quy ước code đang theo (`CLAUDE.md`) và cách viết CHANGELOG.
- **`.github/pull_request_template.md`** (mới): khung PR có mục Tóm tắt / Thay đổi chính / Test / Ảnh hưởng, để người đóng góp điền thay vì để trống.
- **`.github/CODEOWNERS`** (mới): gắn `@blogminhquy` làm reviewer mặc định cho mọi PR (`* @blogminhquy`).
- **`README.md` + `README.en.md`**: thêm mục "☕ Ủng hộ Javis OS" / "☕ Support Javis OS" (MB Bank, MoMo, PayPal), đặt trước footer.

Phần còn lại **không có tool API cho** và cần làm tay trên GitHub UI (đã báo trong chat riêng với chủ repo):
- Bật **branch protection** cho `main`: Settings → Branches → Add rule → *Require a pull request before merging*, tick *Require status checks to pass* (chọn job `test` của CI đang có), có thể thêm *Require review from Code Owners* để CODEOWNERS ở trên thật sự chặn merge chứ không chỉ gắn tên.

Không đổi hành vi app (không phải file dashboard/server), nên không bump `VERSION`/`CHANGELOG.md` - đây là thay đổi quy trình repo + tài liệu, không phải tính năng người dùng cuối thấy được trong app.

## Test plan
- [x] `python tests/run.py --js` - 43/43 xanh
- [x] `python tests/python/test_tai_lieu_song_ngu.py` - xanh (link nội bộ, số liệu song ngữ khớp, không em dash)
- [x] Không đụng file app nào (`dashboard/`, `server/`) nên không cần chạy lại test Python liên quan tới runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)