### PR TITLE
CI tự chạy khi đẩy lên nhánh claude/**, hết phải bấm tay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,19 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    # `claude/**` là các nhánh phiên Claude Code làm việc trên repo này. Chúng luôn đẩy commit
+    # lên TRƯỚC rồi mới mở PR, mà lúc đó chưa có PR nên `pull_request` không bắt được, và mở
+    # PR sau đó có lúc GitHub không sinh run cho commit đã nằm sẵn ở nhánh. Kết quả: nhiều lần
+    # phải vào tab Actions bấm chạy tay, dễ sót. Nghe `push` trên đúng tiền tố này thì commit
+    # vừa lên là CI chạy ngay.
+    # Nhánh có PR mở sẽ chạy hai lần (một do push, một do pull_request). Chấp nhận: repo public
+    # nên Actions không tính phút, và hai run xanh đọc rõ hơn là một run bị huỷ giữa chừng.
+    branches: [ main, 'claude/**' ]
+  # BẮT BUỘC giữ: PR từ fork KHÔNG sinh sự kiện `push` ở repo này, chỉ `pull_request` mới bắt
+  # được. Repo đang có hơn 100 fork nên bỏ dòng này là đóng CI với mọi đóng góp bên ngoài.
   pull_request:
-  # Chạy tay từ tab Actions. Cần vì có một khe hở thật: đẩy commit lên một nhánh CHƯA có PR mở
-  # thì không sự kiện nào bắt (push chỉ nghe `main`), và mở PR sau đó có lúc GitHub không sinh
-  # run cho commit đã nằm sẵn ở đó. Lúc ấy không có cách nào bắt CI chạy ngoài việc đẩy thêm
-  # một commit rác. Có nút chạy tay thì hết phải làm vậy.
+  # Chạy tay từ tab Actions. Vẫn giữ làm lối thoát cho nhánh không mang tiền tố `claude/`, và
+  # cho việc chạy lại một commit cũ mà không phải đẩy thêm commit rác.
   workflow_dispatch:
 
 jobs:

--- a/tests/python/test_ci_trigger.py
+++ b/tests/python/test_ci_trigger.py
@@ -1,0 +1,55 @@
+"""Khối `on:` của CI: đủ ba cửa vào, và không cửa nào được lặng lẽ biến mất.
+
+Ba dòng trong đó không phải chuyện thẩm mỹ, mỗi dòng bịt một khe hở KHÁC nhau:
+
+- `push` nghe `claude/**`: phiên Claude Code luôn đẩy commit lên nhánh TRƯỚC rồi mới mở PR.
+  Lúc đẩy thì chưa có PR nên `pull_request` không bắt, mà mở PR sau đó có lúc GitHub không
+  sinh run cho commit đã nằm sẵn. Thiếu dòng này là quay lại cảnh phải vào tab Actions bấm
+  tay mỗi lần, và có lần sót thật (0.49.x).
+- `pull_request`: PR từ fork KHÔNG sinh sự kiện `push` ở repo gốc. Repo đang có hơn 100 fork
+  nên bỏ dòng này là đóng CI với mọi đóng góp bên ngoài - đúng nhóm PR cần soi nhất.
+- `workflow_dispatch`: lối thoát để chạy lại một commit cũ mà không phải đẩy commit rác.
+
+Test này KHÔNG parse YAML bằng thư viện ngoài (CI chỉ cài requirements.txt + pytest), chỉ
+đọc thô khối `on:` - đủ để bắt việc xoá nhầm.
+"""
+import re  # noqa: E402
+from _paths import ROOT  # noqa: E402,F401
+
+CI = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+fails = []
+
+
+def check(name: str, condition: bool) -> None:
+    print(("PASS: " if condition else "FAIL: ") + name)
+    if not condition:
+        fails.append(name)
+
+
+# Cắt đúng khối `on:` (từ dòng `on:` tới `jobs:`) rồi bỏ hết dòng chú thích. Soi nguyên file
+# thì một chữ nằm trong comment cũng làm test xanh oan - đúng kiểu canary vô dụng.
+_khoi = CI.split("\non:", 1)[1].split("\njobs:", 1)[0]
+ON = "\n".join(d for d in _khoi.splitlines() if not d.strip().startswith("#"))
+
+check("có nghe sự kiện push", re.search(r"^\s*push:\s*$", ON, re.M) is not None)
+_br = re.search(r"^\s*branches:\s*\[(.*?)\]\s*$", ON, re.M)
+_ten = [t.strip().strip("'\"") for t in _br.group(1).split(",")] if _br else []
+check("push vẫn nghe main", "main" in _ten)
+# CANARY chính của test này. Đây là dòng vừa thêm ở 0.49.4, và cũng là dòng dễ bị dọn nhầm
+# nhất về sau vì nhìn qua tưởng là nhánh rác của một phiên làm việc cũ.
+check("CANARY: push nghe nhánh claude/** (thiếu là phải bấm CI bằng tay)",
+      "claude/**" in _ten)
+check("pull_request còn nguyên (cửa duy nhất của PR từ fork)",
+      re.search(r"^\s*pull_request:\s*$", ON, re.M) is not None)
+check("workflow_dispatch còn nguyên (lối chạy lại commit cũ)",
+      re.search(r"^\s*workflow_dispatch:\s*$", ON, re.M) is not None)
+# Lý do ba dòng trên tồn tại nằm ở chú thích ngay cạnh chúng. Mất chú thích thì người sau
+# đọc file chỉ thấy ba dòng trơ và rất dễ rút gọn lại.
+check("lý do vì sao nghe claude/** được ghi ngay trong file",
+      "claude/**" in CI and "chưa có PR" in CI)
+check("lý do vì sao KHÔNG bỏ pull_request được ghi ngay trong file", "fork" in CI)
+
+if fails:
+    raise SystemExit(f"\nFAIL - test_ci_trigger: {len(fails)} lỗi")
+print("\nOK - test_ci_trigger: tất cả pass")


### PR DESCRIPTION
## Vấn đề

Phiên Claude Code làm việc trên repo này luôn **đẩy commit lên nhánh TRƯỚC rồi mới mở PR**. Lúc đẩy thì chưa có PR nên `pull_request` không bắt được, còn `push` chỉ nghe `main`. Mở PR sau đó cũng có lúc GitHub không sinh run cho commit đã nằm sẵn ở nhánh.

Kết quả: mỗi lần phải vào tab Actions bấm `workflow_dispatch` bằng tay, và trong loạt 0.49.x đã có lần sót thật.

## Thay đổi

Thêm `claude/**` vào `push.branches`. Commit vừa lên nhánh là CI chạy ngay.

**Nhánh đang có PR mở sẽ chạy hai lần** (một do `push`, một do `pull_request`). Đây là lựa chọn có chủ đích chứ không phải bỏ sót: repo public nên Actions không tính phút, và hai run xanh thì đọc rõ ràng hơn là dựng `concurrency: cancel-in-progress` để rồi trên PR hiện một run **"cancelled"** mà cả người đọc lẫn tự động hoá đều phải đoán xem nó có phải lỗi không.

Hai cửa vào cũ giữ nguyên vì mỗi cửa có việc riêng:
- `pull_request` - **PR từ fork KHÔNG sinh sự kiện `push`** ở repo gốc. Repo đang có hơn 100 fork nên bỏ dòng này là đóng CI với mọi đóng góp bên ngoài.
- `workflow_dispatch` - lối chạy lại một commit cũ mà không phải đẩy commit rác.

## Test

- [x] `python tests/run.py` xanh - **271/271**
- [x] `test_ci_trigger.py` mới ghim cả ba cửa vào kèm lý do ngay trong file. Cần thiết vì nhìn qua thì `claude/**` rất dễ bị dọn nhầm như nhánh rác của một phiên cũ.
- [x] **Đã thử đột biến**: bỏ `claude/**` hoặc bỏ `pull_request` đều làm test đỏ đúng dòng đó, không phải canary xanh suông.
- [x] Test cắt đúng khối `on:` rồi mới soi, và bỏ hết dòng chú thích - nếu soi cả file thì một chữ nằm trong comment cũng làm test xanh oan.
- [x] Phép thử sống: chính cú push mở PR này phải tự sinh run mà không ai bấm gì.

## Ảnh hưởng

Chỉ hạ tầng phát triển, không đụng một dòng nào của app.

**Không bump VERSION/CHANGELOG** có chủ đích: người dùng app không thấy gì khác, nên phát hành một bản chỉ để bảo mọi người redeploy là nhiễu. `test_version_khop_changelog` vẫn xanh vì `VERSION` giữ nguyên 0.49.3 khớp mục mới nhất.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UMJ9Fk5dPwmCmAFZiaTnR

---
_Generated by [Claude Code](https://claude.ai/code/session_017UMJ9Fk5dPwmCmAFZiaTnR)_