### PR TITLE
Project đợt 1: kho + API cho hướng dẫn, tài liệu và link

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -10478,13 +10478,108 @@ async def projects_create(name: str = Form(...), icon: str = Form(""),
     return {"ok": True, "id": pid}
 
 
+@app.get("/projects/{project_id}")
+async def projects_get(project_id: str):
+    """Project ĐẦY ĐỦ: hướng dẫn + danh sách file + link. Chỉ gọi khi mở khung project.
+
+    Route riêng chứ không nhồi vào `GET /projects`: danh sách bên trái vẽ lại mỗi lần đổi
+    brain/bộ lọc/tạo hội thoại, kéo theo hướng dẫn của từng project mỗi lượt là trả giá cho
+    thứ không ai nhìn. Ở đó chỉ cần `file_count`/`link_count`/`has_instructions`.
+    """
+    p = get_store().get_project_full(project_id)
+    if not p:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return {"ok": True, "project": p}
+
+
 @app.post("/projects/{project_id}/update")
-async def projects_update(project_id: str, name: str = Form(None), icon: str = Form(None)):
+async def projects_update(project_id: str, name: str = Form(None), icon: str = Form(None),
+                          instructions: str = Form(None)):
     store = get_store()
     if not store.get_project(project_id):
         return JSONResponse({"error": "not found"}, status_code=404)
-    store.update_project(project_id, name=name, icon=icon)
+    store.update_project(project_id, name=name, icon=icon, instructions=instructions)
     return {"ok": True}
+
+
+# ── Tài liệu & link của project ───────────────────────────────────────────────
+#
+# Brain LẤY TỪ PROJECT (`p["brain"]`), tuyệt đối không nhận từ client. Project thuộc đúng một
+# brain, và đường dẫn file chỉ có nghĩa trong brain đó; cho client khai brain là mở đường cho
+# một project trỏ sang file của brain khác - phá đúng cái rào `_safe_path` đang giữ.
+
+def _proj_or_404(project_id: str):
+    p = get_store().get_project(project_id)
+    return p, (None if p else JSONResponse({"error": "not found"}, status_code=404))
+
+
+@app.post("/projects/{project_id}/files")
+async def projects_add_file(project_id: str, path: str = Form(...), name: str = Form("")):
+    p, err = _proj_or_404(project_id)
+    if err:
+        return err
+    try:
+        # Kiểm đường dẫn TRƯỚC khi ghi DB. Kho không biết brain nào nên không tự kiểm được;
+        # bỏ bước này là lưu được một path trèo ra ngoài brain rồi mới vỡ lúc đọc.
+        alo = _safe_path(p.get("brain") or "brain", path)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    if not alo.exists():
+        return JSONResponse({"error": "Không tìm thấy file trong brain này"}, status_code=404)
+    fid = get_store().add_project_file(project_id, path, name or alo.name)
+    if not fid:
+        return JSONResponse({"error": "thiếu đường dẫn"}, status_code=400)
+    return {"ok": True, "id": fid}
+
+
+@app.post("/projects/{project_id}/files/{file_id}/delete")
+async def projects_del_file(project_id: str, file_id: str):
+    """GỠ KHỎI PROJECT, KHÔNG xoá file trên đĩa. File nằm trong brain và có đời sống riêng."""
+    p, err = _proj_or_404(project_id)
+    if err:
+        return err
+    return {"ok": get_store().remove_project_file(project_id, file_id)}
+
+
+@app.post("/projects/{project_id}/files/{file_id}/pin")
+async def projects_pin_file(project_id: str, file_id: str, pinned: str = Form("1")):
+    p, err = _proj_or_404(project_id)
+    if err:
+        return err
+    on = str(pinned).strip() in ("1", "true", "True", "on")
+    return {"ok": get_store().set_project_file_pinned(project_id, file_id, on), "pinned": on}
+
+
+@app.post("/projects/{project_id}/links")
+async def projects_add_link(project_id: str, url: str = Form(...), label: str = Form("")):
+    p, err = _proj_or_404(project_id)
+    if err:
+        return err
+    u = (url or "").strip()
+    # Chỉ nhận http/https. Không rào thì `javascript:` hay `file:` lọt vào danh sách rồi hiện
+    # thành liên kết bấm được ngay trong giao diện.
+    if not re.match(r"^https?://", u, re.I):
+        return JSONResponse({"error": "URL phải bắt đầu bằng http:// hoặc https://"},
+                            status_code=400)
+    lid = get_store().add_project_link(project_id, u, label)
+    return {"ok": True, "id": lid}
+
+
+@app.post("/projects/{project_id}/links/{link_id}/delete")
+async def projects_del_link(project_id: str, link_id: str):
+    p, err = _proj_or_404(project_id)
+    if err:
+        return err
+    return {"ok": get_store().remove_project_link(project_id, link_id)}
+
+
+@app.post("/projects/{project_id}/links/{link_id}/pin")
+async def projects_pin_link(project_id: str, link_id: str, pinned: str = Form("1")):
+    p, err = _proj_or_404(project_id)
+    if err:
+        return err
+    on = str(pinned).strip() in ("1", "true", "True", "on")
+    return {"ok": get_store().set_project_link_pinned(project_id, link_id, on), "pinned": on}
 
 
 @app.post("/projects/{project_id}/delete")

--- a/server/sessions.py
+++ b/server/sessions.py
@@ -99,10 +99,37 @@ CREATE TABLE IF NOT EXISTS projects (
     updated_at REAL NOT NULL
 );
 
+-- Tài liệu và link gắn vào một project. KHÔNG có cột `brain`: project đã thuộc đúng một
+-- brain (`projects.brain`), và đường dẫn file chỉ có nghĩa TRONG brain đó. Lưu brain lần nữa
+-- ở đây là mở cửa cho một project trỏ sang file của brain khác - phá đúng cái rào `_safe_path`
+-- đang giữ, mà lại phá bằng dữ liệu chứ không phải bằng lỗi code, nên không rào nào bắt được.
+-- Cùng lý do như `sessions.project_id`: không khai REFERENCES (SQLite không ALTER kèm khoá
+-- ngoại), ràng buộc giữ ở tầng code - `delete_project` xoá kèm trong CÙNG transaction.
+CREATE TABLE IF NOT EXISTS project_files (
+    id         TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL,
+    path       TEXT NOT NULL,
+    name       TEXT NOT NULL,
+    pinned     INTEGER NOT NULL DEFAULT 0,
+    added_at   REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS project_links (
+    id         TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL,
+    url        TEXT NOT NULL,
+    label      TEXT,
+    pinned     INTEGER NOT NULL DEFAULT 0,
+    added_at   REAL NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_brain   ON sessions(brain, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_updated ON sessions(updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, ts);
 CREATE INDEX IF NOT EXISTS idx_projects_brain   ON projects(brain, updated_at DESC);
+-- Thứ tự index khớp ĐÚNG thứ tự đọc ra (ghim lên đầu, mới nhất trước) để khỏi sort lại.
+CREATE INDEX IF NOT EXISTS idx_pf_project ON project_files(project_id, pinned DESC, added_at DESC);
+CREATE INDEX IF NOT EXISTS idx_pl_project ON project_links(project_id, pinned DESC, added_at DESC);
 """
 
 # FTS5 mirror giữ đồng bộ qua trigger (shape port từ hermes_state.py:738-761).
@@ -212,6 +239,12 @@ def title_from_message(msg: str, gioi_han: int = TITLE_MAX) -> str:
         return "File đính kèm"
     return ""
 
+
+# Trần hướng dẫn của một project. Khối này ghép vào system prompt của MỌI lượt chat trong
+# project đó, y như CLAUDE.md và MEMORY.md - nên nó là chi phí LẶP LẠI, không phải chi phí một
+# lần. 4000 ký tự đủ cho một bản brief tông giọng/màu sắc/luật riêng, và đủ hẹp để một project
+# không âm thầm nuốt ngân sách token của mọi câu hỏi trong đó.
+PROJECT_INSTRUCTIONS_MAX = 4000
 
 # Tên icon Lucide: chữ thường, số và gạch nối (vd "message-circle"). Cột `projects.icon` lưu
 # TÊN icon chứ không phải ký tự emoji: icon Lucide tự đổi màu theo tông sáng/tối và vẽ giống
@@ -328,6 +361,13 @@ class SessionStore:
             self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_sessions_project "
                 "ON sessions(project_id, updated_at DESC)")
+            # Hướng dẫn riêng của project, ghép vào system prompt mỗi lượt chat trong đó.
+            cols_p = {r[1] for r in self._conn.execute(
+                "PRAGMA table_info(projects)").fetchall()}
+            for name, ddl in (("instructions", "TEXT"),):
+                if name not in cols_p:
+                    self._conn.execute(
+                        f"ALTER TABLE projects ADD COLUMN {name} {ddl}")
             if self._probe_fts5():
                 try:
                     self._conn.executescript(_FTS_SQL)
@@ -560,7 +600,12 @@ class SessionStore:
         rows = self._read(
             f"""
             SELECT p.id, p.name, p.icon, p.brain, p.created_at, p.updated_at,
-                   (SELECT COUNT(*) FROM sessions s WHERE s.project_id = p.id) AS session_count
+                   (SELECT COUNT(*) FROM sessions s WHERE s.project_id = p.id) AS session_count,
+                   (SELECT COUNT(*) FROM project_files f WHERE f.project_id = p.id) AS file_count,
+                   (SELECT COUNT(*) FROM project_links l WHERE l.project_id = p.id) AS link_count,
+                   -- Chỉ CÓ hay KHÔNG, không kéo cả 4000 ký tự về cho một danh sách bên trái.
+                   (CASE WHEN COALESCE(TRIM(p.instructions), '') <> '' THEN 1 ELSE 0 END)
+                       AS has_instructions
             FROM projects p
             {where_sql}
             ORDER BY p.updated_at DESC
@@ -573,9 +618,28 @@ class SessionStore:
         rows = self._read("SELECT * FROM projects WHERE id = ?", (project_id,))
         return dict(rows[0]) if rows else None
 
+    def get_project_full(self, project_id: str) -> Optional[Dict[str, Any]]:
+        """Project kèm hướng dẫn + danh sách file + link. Chỉ dùng khi MỞ khung project.
+
+        Tách khỏi `list_projects` là cố ý: danh sách ở cột bên trái vẽ lại mỗi lần đổi brain,
+        đổi bộ lọc, tạo hội thoại - kéo theo hướng dẫn 4000 ký tự của từng project mỗi lượt là
+        trả giá cho thứ không ai nhìn. Ở đó chỉ cần hai con số đếm.
+        """
+        p = self.get_project(project_id)
+        if not p:
+            return None
+        p["files"] = [dict(r) for r in self._read(
+            "SELECT id, path, name, pinned, added_at FROM project_files "
+            "WHERE project_id = ? ORDER BY pinned DESC, added_at DESC", (project_id,))]
+        p["links"] = [dict(r) for r in self._read(
+            "SELECT id, url, label, pinned, added_at FROM project_links "
+            "WHERE project_id = ? ORDER BY pinned DESC, added_at DESC", (project_id,))]
+        return p
+
     def update_project(self, project_id: str, *, name: Optional[str] = None,
-                       icon: Optional[str] = None) -> None:
-        """Đổi tên và/hoặc icon. Tham số None = không đụng tới; icon = "" là GỠ icon."""
+                       icon: Optional[str] = None,
+                       instructions: Optional[str] = None) -> None:
+        """Đổi tên, icon và/hoặc hướng dẫn. Tham số None = không đụng tới; "" là GỠ."""
         sets, params = [], []
         if name is not None:
             n = (name or "").strip()[:80]
@@ -585,6 +649,12 @@ class SessionStore:
         if icon is not None:
             sets.append("icon = ?")
             params.append(_sach_icon(icon))
+        if instructions is not None:
+            # Cắt NGAY LÚC LƯU, không chỉ lúc dựng prompt. Trần ở tầng prompt một mình thì kho
+            # vẫn phình theo mỗi lần gõ, và người dùng thấy chữ mình lưu được nhưng Javis lặng
+            # lẽ chỉ đọc một phần - kiểu hỏng không ai truy ra.
+            sets.append("instructions = ?")
+            params.append((instructions or "").strip()[:PROJECT_INSTRUCTIONS_MAX])
         if not sets:
             return
         sets.append("updated_at = ?")
@@ -603,9 +673,76 @@ class SessionStore:
             cur = conn.execute("UPDATE sessions SET project_id = NULL WHERE project_id = ?",
                                (project_id,))
             n = cur.rowcount or 0
+            # Tài liệu và link đi theo project (khác hội thoại - hội thoại chỉ bị gỡ nhãn).
+            # Chúng KHÔNG có nghĩa gì ngoài project, để lại là rác mồ côi. Xoá ở đây, trong
+            # CÙNG transaction, chứ không phải một lượt dọn riêng có thể không bao giờ chạy.
+            conn.execute("DELETE FROM project_files WHERE project_id = ?", (project_id,))
+            conn.execute("DELETE FROM project_links WHERE project_id = ?", (project_id,))
             conn.execute("DELETE FROM projects WHERE id = ?", (project_id,))
             return n
         return self._write(_do)
+
+    # ── tài liệu & link của project ──
+    #
+    # Xoá ở đây là GỠ KHỎI PROJECT, không đụng file trên đĩa. File nằm trong brain và có đời
+    # sống riêng; gỡ nhãn mà xoá luôn file thì một cú bấm nhầm mất dữ liệu thật.
+
+    def add_project_file(self, project_id: str, path: str, name: str = "") -> Optional[str]:
+        """Gắn một file có sẵn trong brain vào project. Trùng đường dẫn thì KHÔNG thêm lần hai.
+
+        Đường dẫn phải được caller kiểm bằng rào path của brain TRƯỚC khi gọi (xem
+        `main._safe_path`): kho này không biết brain nào, và không được đoán.
+        """
+        rel = (path or "").strip()
+        if not rel:
+            return None
+        cu = self._read("SELECT id FROM project_files WHERE project_id = ? AND path = ?",
+                        (project_id, rel))
+        if cu:
+            return str(cu[0]["id"])
+        fid = uuid.uuid4().hex
+        ten = (name or "").strip() or rel.replace("\\", "/").split("/")[-1]
+        self._write(lambda c: c.execute(
+            "INSERT INTO project_files (id, project_id, path, name, pinned, added_at) "
+            "VALUES (?, ?, ?, ?, 0, ?)", (fid, project_id, rel, ten[:160], time.time())))
+        return fid
+
+    def remove_project_file(self, project_id: str, file_id: str) -> bool:
+        # Kèm project_id trong WHERE: id là uuid nên khó đụng, nhưng một route nhận id từ
+        # client thì không được phép xoá bản ghi của project khác chỉ vì đoán trúng id.
+        return bool(self._write(lambda c: c.execute(
+            "DELETE FROM project_files WHERE id = ? AND project_id = ?",
+            (file_id, project_id))).rowcount)
+
+    def set_project_file_pinned(self, project_id: str, file_id: str, pinned: bool) -> bool:
+        return bool(self._write(lambda c: c.execute(
+            "UPDATE project_files SET pinned = ? WHERE id = ? AND project_id = ?",
+            (1 if pinned else 0, file_id, project_id))).rowcount)
+
+    def add_project_link(self, project_id: str, url: str, label: str = "") -> Optional[str]:
+        u = (url or "").strip()
+        if not u:
+            return None
+        cu = self._read("SELECT id FROM project_links WHERE project_id = ? AND url = ?",
+                        (project_id, u))
+        if cu:
+            return str(cu[0]["id"])
+        lid = uuid.uuid4().hex
+        self._write(lambda c: c.execute(
+            "INSERT INTO project_links (id, project_id, url, label, pinned, added_at) "
+            "VALUES (?, ?, ?, ?, 0, ?)",
+            (lid, project_id, u[:2000], (label or "").strip()[:160], time.time())))
+        return lid
+
+    def remove_project_link(self, project_id: str, link_id: str) -> bool:
+        return bool(self._write(lambda c: c.execute(
+            "DELETE FROM project_links WHERE id = ? AND project_id = ?",
+            (link_id, project_id))).rowcount)
+
+    def set_project_link_pinned(self, project_id: str, link_id: str, pinned: bool) -> bool:
+        return bool(self._write(lambda c: c.execute(
+            "UPDATE project_links SET pinned = ? WHERE id = ? AND project_id = ?",
+            (1 if pinned else 0, link_id, project_id))).rowcount)
 
     def rename(self, session_id: str, title: str) -> None:
         self._write(lambda c: c.execute(

--- a/tests/python/route_table.json
+++ b/tests/python/route_table.json
@@ -2041,6 +2041,15 @@
  {
   "order": 227,
   "type": "APIRoute",
+  "path": "/projects/{project_id}",
+  "name": "projects_get",
+  "methods": [
+   "GET"
+  ]
+ },
+ {
+  "order": 228,
+  "type": "APIRoute",
   "path": "/projects/{project_id}/update",
   "name": "projects_update",
   "methods": [
@@ -2048,7 +2057,61 @@
   ]
  },
  {
-  "order": 228,
+  "order": 229,
+  "type": "APIRoute",
+  "path": "/projects/{project_id}/files",
+  "name": "projects_add_file",
+  "methods": [
+   "POST"
+  ]
+ },
+ {
+  "order": 230,
+  "type": "APIRoute",
+  "path": "/projects/{project_id}/files/{file_id}/delete",
+  "name": "projects_del_file",
+  "methods": [
+   "POST"
+  ]
+ },
+ {
+  "order": 231,
+  "type": "APIRoute",
+  "path": "/projects/{project_id}/files/{file_id}/pin",
+  "name": "projects_pin_file",
+  "methods": [
+   "POST"
+  ]
+ },
+ {
+  "order": 232,
+  "type": "APIRoute",
+  "path": "/projects/{project_id}/links",
+  "name": "projects_add_link",
+  "methods": [
+   "POST"
+  ]
+ },
+ {
+  "order": 233,
+  "type": "APIRoute",
+  "path": "/projects/{project_id}/links/{link_id}/delete",
+  "name": "projects_del_link",
+  "methods": [
+   "POST"
+  ]
+ },
+ {
+  "order": 234,
+  "type": "APIRoute",
+  "path": "/projects/{project_id}/links/{link_id}/pin",
+  "name": "projects_pin_link",
+  "methods": [
+   "POST"
+  ]
+ },
+ {
+  "order": 235,
   "type": "APIRoute",
   "path": "/projects/{project_id}/delete",
   "name": "projects_delete",
@@ -2057,7 +2120,7 @@
   ]
  },
  {
-  "order": 229,
+  "order": 236,
   "type": "APIRoute",
   "path": "/runtime/diagnostics",
   "name": "runtime_diagnostics",
@@ -2066,7 +2129,7 @@
   ]
  },
  {
-  "order": 230,
+  "order": 237,
   "type": "APIRoute",
   "path": "/runtime/muc",
   "name": "runtime_muc",
@@ -2075,7 +2138,7 @@
   ]
  },
  {
-  "order": 231,
+  "order": 238,
   "type": "APIRoute",
   "path": "/runtime/preset",
   "name": "runtime_preset_set",
@@ -2084,7 +2147,7 @@
   ]
  },
  {
-  "order": 232,
+  "order": 239,
   "type": "APIRoute",
   "path": "/runtime/mode",
   "name": "runtime_mode_set",
@@ -2093,7 +2156,7 @@
   ]
  },
  {
-  "order": 233,
+  "order": 240,
   "type": "APIRoute",
   "path": "/runtime/quota",
   "name": "runtime_quota_apply",
@@ -2102,7 +2165,7 @@
   ]
  },
  {
-  "order": 234,
+  "order": 241,
   "type": "APIRoute",
   "path": "/runtime/canary",
   "name": "runtime_canary_set",
@@ -2111,7 +2174,7 @@
   ]
  },
  {
-  "order": 235,
+  "order": 242,
   "type": "APIRoute",
   "path": "/runtime/tasks/{task_id}",
   "name": "runtime_task_status",
@@ -2120,7 +2183,7 @@
   ]
  },
  {
-  "order": 236,
+  "order": 243,
   "type": "APIRoute",
   "path": "/runtime/tasks/{task_id}/resume",
   "name": "runtime_task_resume",
@@ -2129,7 +2192,7 @@
   ]
  },
  {
-  "order": 237,
+  "order": 244,
   "type": "APIRoute",
   "path": "/zalo-bot/status",
   "name": "zalo_bot_status",
@@ -2138,7 +2201,7 @@
   ]
  },
  {
-  "order": 238,
+  "order": 245,
   "type": "APIRoute",
   "path": "/zalo-bot/restart",
   "name": "zalo_bot_restart",
@@ -2147,7 +2210,7 @@
   ]
  },
  {
-  "order": 239,
+  "order": 246,
   "type": "APIRoute",
   "path": "/zalo-bot/allow",
   "name": "zalo_bot_allow",
@@ -2156,7 +2219,7 @@
   ]
  },
  {
-  "order": 240,
+  "order": 247,
   "type": "APIRoute",
   "path": "/zalo-bot/test",
   "name": "zalo_bot_test",
@@ -2165,7 +2228,7 @@
   ]
  },
  {
-  "order": 241,
+  "order": 248,
   "type": "APIRoute",
   "path": "/telegram/status",
   "name": "telegram_status",
@@ -2174,7 +2237,7 @@
   ]
  },
  {
-  "order": 242,
+  "order": 249,
   "type": "APIRoute",
   "path": "/telegram/restart",
   "name": "telegram_restart",
@@ -2183,7 +2246,7 @@
   ]
  },
  {
-  "order": 243,
+  "order": 250,
   "type": "APIRoute",
   "path": "/chatbots",
   "name": "chatbots_list",
@@ -2192,7 +2255,7 @@
   ]
  },
  {
-  "order": 244,
+  "order": 251,
   "type": "APIRoute",
   "path": "/chatbots/verify-token",
   "name": "chatbots_verify_token",
@@ -2201,7 +2264,7 @@
   ]
  },
  {
-  "order": 245,
+  "order": 252,
   "type": "APIRoute",
   "path": "/chatbots",
   "name": "chatbots_create",
@@ -2210,7 +2273,7 @@
   ]
  },
  {
-  "order": 246,
+  "order": 253,
   "type": "APIRoute",
   "path": "/chatbots/{bot_id}/update",
   "name": "chatbots_update",
@@ -2219,7 +2282,7 @@
   ]
  },
  {
-  "order": 247,
+  "order": 254,
   "type": "APIRoute",
   "path": "/chatbots/{bot_id}/enable",
   "name": "chatbots_enable",
@@ -2228,7 +2291,7 @@
   ]
  },
  {
-  "order": 248,
+  "order": 255,
   "type": "APIRoute",
   "path": "/chatbots/{bot_id}/groups",
   "name": "chatbots_groups",
@@ -2237,7 +2300,7 @@
   ]
  },
  {
-  "order": 249,
+  "order": 256,
   "type": "APIRoute",
   "path": "/chatbots/{bot_id}/log",
   "name": "chatbots_log",
@@ -2246,7 +2309,7 @@
   ]
  },
  {
-  "order": 250,
+  "order": 257,
   "type": "APIRoute",
   "path": "/chatbots/{bot_id}/delete",
   "name": "chatbots_delete",
@@ -2255,7 +2318,7 @@
   ]
  },
  {
-  "order": 251,
+  "order": 258,
   "type": "APIRoute",
   "path": "/telegram/test",
   "name": "telegram_test",
@@ -2264,7 +2327,7 @@
   ]
  },
  {
-  "order": 252,
+  "order": 259,
   "type": "APIRoute",
   "path": "/chat",
   "name": "chat_once",
@@ -2273,7 +2336,7 @@
   ]
  },
  {
-  "order": 253,
+  "order": 260,
   "type": "APIRoute",
   "path": "/chat/stream",
   "name": "chat_stream",
@@ -2282,7 +2345,7 @@
   ]
  },
  {
-  "order": 254,
+  "order": 261,
   "type": "APIRoute",
   "path": "/telegram/send-file",
   "name": "telegram_send_file",

--- a/tests/python/test_project_khung.py
+++ b/tests/python/test_project_khung.py
@@ -1,0 +1,153 @@
+"""Khung Project: hướng dẫn + tài liệu + link gắn vào một nhóm hội thoại.
+
+    python tests/run.py project_khung      (KHÔNG mạng)
+
+Trước đợt này `projects` chỉ là CÁI NHÃN gom hội thoại cho đỡ rối - không đổi hành vi Javis
+một chút nào. Đợt 1 dựng phần kho + API để nó mang được nội dung: hướng dẫn riêng, danh sách
+tài liệu trong brain, danh sách link.
+
+Hai quyết định đáng canh, vì cả hai đều có cách làm sai trông hợp lý hơn:
+
+1. `project_files` KHÔNG có cột `brain`. Spec ban đầu có. Nhưng project đã thuộc đúng một
+   brain (`projects.brain`), và đường dẫn file chỉ có nghĩa trong brain đó. Lưu brain lần nữa
+   ở đây là mở cửa cho một project trỏ sang file của brain khác - phá đúng cái rào `_safe_path`
+   đang giữ, mà phá bằng DỮ LIỆU chứ không bằng lỗi code, nên không rào nào bắt được. Brain
+   luôn lấy từ project.
+
+2. Xoá project thì hội thoại chỉ bị GỠ NHÃN, còn file/link thì XOÁ HẲN. Không phải bất nhất:
+   hội thoại có đời sống riêng ngoài project, còn tài liệu-của-project thì không có nghĩa gì
+   khi project không còn - để lại là rác mồ côi.
+"""
+from _paths import ROOT, SERVER  # noqa: E402,F401
+import os
+import tempfile
+
+os.environ.setdefault("JAVIS_STATE_DIR", tempfile.mkdtemp(prefix="javis-proj-"))
+
+import sessions  # noqa: E402
+
+_fails = []
+
+
+def check(ten, dieu_kien, them=""):
+    print(("ok   " if dieu_kien else "FAIL ") + ten
+          + (("  [" + str(them) + "]") if them and not dieu_kien else ""))
+    if not dieu_kien:
+        _fails.append(ten)
+
+
+st = sessions.SessionStore(os.path.join(tempfile.mkdtemp(prefix="javis-proj-db-"), "s.db"))
+
+# ============================================================
+# 1. Hướng dẫn: lưu, sửa, gỡ, và CẮT NGAY LÚC LƯU
+# ============================================================
+pid = st.create_project("Mộc Việt", brain="brain")
+check("project mới chưa có hướng dẫn", not (st.get_project(pid) or {}).get("instructions"))
+
+st.update_project(pid, instructions="Tông xanh lá. Tránh xanh dương.")
+check("lưu được hướng dẫn",
+      st.get_project(pid)["instructions"] == "Tông xanh lá. Tránh xanh dương.")
+
+st.update_project(pid, name="Mộc Việt 2")
+check("đổi tên KHÔNG xoá mất hướng dẫn (None = không đụng tới)",
+      st.get_project(pid)["instructions"] == "Tông xanh lá. Tránh xanh dương.")
+
+st.update_project(pid, instructions="")
+check('truyền "" là GỠ hướng dẫn', st.get_project(pid)["instructions"] == "")
+
+# Cắt ở tầng KHO chứ không chỉ lúc dựng prompt: chặn ở prompt thôi thì kho vẫn phình theo mỗi
+# lần gõ, và người dùng thấy chữ mình lưu được nhưng Javis lặng lẽ chỉ đọc một phần.
+st.update_project(pid, instructions="x" * (sessions.PROJECT_INSTRUCTIONS_MAX + 500))
+check(f"hướng dẫn bị cắt về trần {sessions.PROJECT_INSTRUCTIONS_MAX} ngay lúc lưu",
+      len(st.get_project(pid)["instructions"]) == sessions.PROJECT_INSTRUCTIONS_MAX,
+      len(st.get_project(pid)["instructions"]))
+st.update_project(pid, instructions="Tông xanh lá.")
+
+# ============================================================
+# 2. Tài liệu & link
+# ============================================================
+f1 = st.add_project_file(pid, "05 - Projects/bang-gia.md")
+check("thêm file, tên suy từ đường dẫn khi không truyền",
+      st.get_project_full(pid)["files"][0]["name"] == "bang-gia.md")
+check("thêm CÙNG đường dẫn lần hai trả lại id cũ, không đẻ bản ghi trùng",
+      st.add_project_file(pid, "05 - Projects/bang-gia.md") == f1
+      and len(st.get_project_full(pid)["files"]) == 1)
+check("đường dẫn rỗng bị từ chối", st.add_project_file(pid, "   ") is None)
+
+f2 = st.add_project_file(pid, "06 - Sources/brief.md", "Brief landing")
+check("tên tự đặt được giữ",
+      any(f["name"] == "Brief landing" for f in st.get_project_full(pid)["files"]))
+
+l1 = st.add_project_link(pid, "https://elegant.vn", "Đối thủ")
+check("thêm link", len(st.get_project_full(pid)["links"]) == 1)
+check("link trùng URL không đẻ bản ghi thứ hai",
+      st.add_project_link(pid, "https://elegant.vn") == l1
+      and len(st.get_project_full(pid)["links"]) == 1)
+
+# Ghim đẩy lên đầu - đây là thứ tự người dùng thấy, và cũng là thứ tự đi vào prompt.
+st.set_project_file_pinned(pid, f2, True)
+check("file được ghim nhảy lên đầu danh sách",
+      st.get_project_full(pid)["files"][0]["id"] == f2,
+      [f["name"] for f in st.get_project_full(pid)["files"]])
+st.set_project_file_pinned(pid, f2, False)
+check("bỏ ghim thì về lại thứ tự mới-nhất-trước",
+      st.get_project_full(pid)["files"][0]["id"] == f2)   # f2 thêm sau nên vẫn đứng đầu
+
+# ============================================================
+# 3. Không được đụng sang project khác dù đoán trúng id
+# ============================================================
+pid2 = st.create_project("Project khác", brain="brain")
+check("xoá file bằng id đúng nhưng SAI project thì không ăn",
+      st.remove_project_file(pid2, f1) is False
+      and len(st.get_project_full(pid)["files"]) == 2)
+check("ghim cũng vậy", st.set_project_file_pinned(pid2, f1, True) is False)
+check("link cũng vậy", st.remove_project_link(pid2, l1) is False)
+
+# ============================================================
+# 4. Danh sách bên trái: chỉ ĐẾM, không kéo cả hướng dẫn về
+# ============================================================
+ds = [p for p in st.list_projects("brain") if p["id"] == pid][0]
+check("list_projects đếm file", ds["file_count"] == 2, ds)
+check("list_projects đếm link", ds["link_count"] == 1, ds)
+check("và chỉ báo CÓ hướng dẫn hay không", ds["has_instructions"] == 1, ds)
+check("KHÔNG kèm nội dung hướng dẫn (danh sách vẽ lại rất nhiều lần)",
+      "instructions" not in ds, list(ds.keys()))
+check("cũng không kèm danh sách file/link", "files" not in ds and "links" not in ds)
+
+# ============================================================
+# 5. Xoá project: hội thoại GỠ NHÃN, file/link XOÁ HẲN
+# ============================================================
+st.get_or_create("s-test", brain="brain", engine="cli", model="sonnet")
+st.set_project("s-test", pid)
+st.delete_project(pid)
+check("project đã xoá", st.get_project(pid) is None)
+check("get_project_full của project đã xoá trả None", st.get_project_full(pid) is None)
+_con_f = st._read("SELECT COUNT(*) c FROM project_files WHERE project_id = ?", (pid,))[0]["c"]
+_con_l = st._read("SELECT COUNT(*) c FROM project_links WHERE project_id = ?", (pid,))[0]["c"]
+check("file của project bị xoá theo, không để rác mồ côi", _con_f == 0, _con_f)
+check("link cũng vậy", _con_l == 0, _con_l)
+_ht = st._read("SELECT COUNT(*) c FROM sessions WHERE id = 's-test'")[0]["c"]
+check("nhưng HỘI THOẠI vẫn còn (chỉ bị gỡ nhãn)", _ht == 1, _ht)
+check("project khác không bị đụng", st.get_project(pid2) is not None)
+
+# ============================================================
+# 6. CANARY nguồn: đừng ai thêm lại cột brain vào project_files
+# ============================================================
+_src = (SERVER / "sessions.py").read_text(encoding="utf-8")
+_bang = _src.split("CREATE TABLE IF NOT EXISTS project_files", 1)[1].split(");", 1)[0]
+check("CANARY: project_files KHÔNG có cột brain (brain lấy từ project)",
+      "brain" not in _bang, _bang)
+_main = (SERVER / "main.py").read_text(encoding="utf-8")
+_them = _main.split("async def projects_add_file", 1)[1].split("\n@app.", 1)[0]
+check("CANARY: route thêm file lấy brain từ PROJECT, không nhận từ client",
+      'p.get("brain")' in _them and "brain: str = Form" not in _them, _them[:200])
+check("CANARY: và kiểm đường dẫn bằng _safe_path trước khi ghi kho",
+      "_safe_path(" in _them, _them[:200])
+_link = _main.split("async def projects_add_link", 1)[1].split("\n@app.", 1)[0]
+check("CANARY: link chỉ nhận http/https", "^https?://" in _link, _link[:200])
+
+print()
+if _fails:
+    print(f"FAIL {len(_fails)}: " + "; ".join(_fails))
+    raise SystemExit(1)
+print("TẤT CẢ PASS")


### PR DESCRIPTION
Đợt 1/3 của khung Project theo spec chủ repo gửi 02/09. Tới nay `projects` chỉ là **cái nhãn** gom hội thoại, không đổi hành vi Javis một chút nào. Đợt này dựng phần kho + API để nó mang được nội dung; bơm vào system prompt (đợt 2) và giao diện (đợt 3) làm sau.

Spec đối chiếu với code thật rất chuẩn: số hiệu dòng, tên hàm, 4 chỗ gọi `build_system_prompt`, schema `projects`, các route sẵn có - đúng hết. Ba chỗ dưới đây là nơi đợt này **đi khác spec**, kèm lý do.

## Khác spec 1: `project_files` KHÔNG có cột `brain`

Spec khai `brain TEXT NOT NULL` trên `project_files`. Bỏ đi, vì `projects.brain` đã có và một project thuộc đúng một brain - đường dẫn file chỉ có nghĩa trong brain đó.

Lưu brain lần nữa ở đây mở cửa cho một project trỏ sang file của **brain khác**. Đó là phá đúng cái rào `_safe_path` đang giữ, mà phá bằng **dữ liệu** chứ không bằng lỗi code, nên không rào nào bắt được: mọi lời gọi đều hợp lệ, chỉ là hợp lệ với sai brain. Lấy brain từ project thì chuyện đó thành không thể xảy ra về mặt cấu trúc.

Route `POST /projects/{id}/files` vì thế **không nhận** `brain` từ client - có canary canh.

## Khác spec 2: trần hướng dẫn cắt ngay lúc lưu

Spec chỉ cắt `[:4000]` lúc dựng prompt. Đợt này cắt ở **cả tầng kho** (`PROJECT_INSTRUCTIONS_MAX`). Chặn ở prompt một mình thì kho vẫn phình theo mỗi lần gõ, và người dùng thấy chữ mình lưu được nhưng Javis lặng lẽ chỉ đọc một phần - kiểu hỏng không ai truy ra.

## Khác spec 3: `list_projects` báo có-hướng-dẫn thay vì trả nội dung

Spec nói thêm `file_count`/`link_count`. Thêm luôn `has_instructions` (0/1) để chip hiện được chấm báo mà không phải kéo cả 4000 ký tự về cho một danh sách vẽ lại mỗi lần đổi brain, đổi bộ lọc, tạo hội thoại.

## Còn lại theo spec

**`server/sessions.py`**
- Cột `instructions` (ALTER cho DB cũ, đúng khuôn migration sẵn có).
- `project_files` / `project_links`, index khớp **đúng thứ tự đọc ra** (`pinned DESC, added_at DESC`) để khỏi sort lại.
- Thêm trùng path/URL trả lại id cũ, không đẻ bản ghi thứ hai.
- Mọi thao tác xoá/ghim kèm `project_id` trong `WHERE`: id là uuid nên khó đụng, nhưng route nhận id từ client thì không được phép sửa bản ghi của project khác chỉ vì đoán trúng id.
- `delete_project` xoá kèm file/link trong **cùng transaction**. Hội thoại vẫn chỉ bị gỡ nhãn - nghe bất nhất nhưng có lý: hội thoại có đời sống riêng ngoài project, còn tài liệu-của-project thì không, để lại là rác mồ côi.

**`server/main.py`**: 7 route. Đường dẫn qua `_safe_path` **và phải tồn tại thật** trước khi ghi kho. Link chỉ nhận `http/https` - không rào thì `javascript:` lọt vào danh sách rồi hiện thành liên kết bấm được ngay trong giao diện.

## Không bump VERSION

Đợt này thuần backend, chưa có giao diện nào để nhập hướng dẫn nên chưa có gì người dùng thấy khác. Một mục CHANGELOG kiểu "thêm hai bảng" đúng là thứ luật repo cấm (viết cho người đọc trên điện thoại, nói cái NHÌN THẤY). Gộp một mục duy nhất mô tả cả tính năng khi đợt 3 xong. `test_version_khop_changelog` vì thế vẫn xanh.

## Test

`tests/python/test_project_khung.py` (không mạng): hướng dẫn lưu/sửa/gỡ và **cắt đúng trần ngay lúc lưu**; đổi tên không xoá mất hướng dẫn; thêm trùng path/URL không đẻ bản ghi; ghim đẩy lên đầu; **xoá/ghim bằng id đúng nhưng sai project thì không ăn**; `list_projects` chỉ đếm chứ không kèm nội dung; xoá project thì file/link đi theo còn hội thoại ở lại; 4 canary nguồn (không có cột brain, route lấy brain từ project, có `_safe_path`, link chặn scheme lạ).

`tests/python/route_table.json` chụp lại: đúng 7 route mới, không mất route nào.

Toàn bộ 289 test xanh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qyB6nzw19bS3F2DMJzXgE

---
_Generated by [Claude Code](https://claude.ai/code/session_014qyB6nzw19bS3F2DMJzXgE)_