### PR TITLE
Project đợt 2: hướng dẫn và tài liệu đi vào system prompt

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -109,6 +109,7 @@ import background_status  # việc nền còn sống của một khung chat + b�
 import chatbot_log       # nhật ký hội thoại khách + thống kê câu bot trả lời không nổi
 import chatbot_runtime   # bộ giám sát Bot chuyên trách (mỗi bot một poller Telegram)
 import chatbot_store     # kho bản ghi bot + token qua secrets_store
+import sessions                  # PROJECT_INSTRUCTIONS_MAX cho khối project trong system prompt
 from sessions import get_store   # kho phiên hội thoại (sqlite + fts5): list/resume/search
 import compaction   # nén hội thoại dài cho engine API (tóm tắt phần cũ thay vì cắt bỏ)
 from chat_runtime import ChatRuntime
@@ -372,10 +373,109 @@ def _fit_memory_index(mem: str, cap: int = None) -> str:
         "Đọc Memory/MEMORY.md để xem đủ danh sách, và Memory/facts/ để xem chi tiết.)")
 
 
+# ── Khối PROJECT ghép vào system prompt ──────────────────────────────────────
+#
+# Đây là thứ biến "Project" từ một cái nhãn lọc giao diện thành thứ THỰC SỰ đổi hành xử.
+#
+# Trần: khối này cộng vào MỌI lượt chat trong project đó, y như CLAUDE.md và MEMORY.md - chi
+# phí LẶP LẠI, không phải chi phí một lần. Nên mọi con số dưới đây là trần cứng, đừng gỡ.
+PROJECT_FILES_LIET_KE = 15      # số file/link LIỆT KÊ tên trong prompt
+PROJECT_GHIM_FILE_MAX = 2000    # ký tự nạp cho MỘT file được ghim
+PROJECT_GHIM_TONG_MAX = 6000    # tổng ký tự nạp cho TẤT CẢ file ghim của một project
+
+# Đuôi file NẠP THẲNG được. Ngoài danh sách này (xlsx, ảnh, pdf, zip...) thì nội dung là nhị
+# phân - nhét vào prompt chỉ ra một đống ký tự vô nghĩa vừa tốn token vừa làm model đoán bừa.
+PROJECT_GHIM_DUOI = {".md", ".txt", ".csv", ".json", ".yaml", ".yml", ".toml", ".ini",
+                     ".py", ".js", ".ts", ".html", ".css", ".sql", ".sh", ".log"}
+
+
+def _project_block(project_id: str, chi_huong_dan: bool = False) -> str:
+    """Khối hướng dẫn + tài liệu của project, để ghép vào system prompt. "" nếu không có gì.
+
+    `chi_huong_dan=True`: CHỈ lấy phần hướng dẫn, bỏ danh sách tài liệu. Dùng cho đường tiết
+    kiệm (Phase 8). Vì sao tách đôi chứ không bỏ cả khối như spec đề nghị: hướng dẫn là HỢP
+    ĐỒNG HÀNH XỬ ("luôn trả lời bằng tiếng Anh", "tránh màu xanh dương"), còn danh sách tài
+    liệu là dữ liệu TRA CỨU. Bỏ dữ liệu tra cứu lúc siết ngân sách thì model cùng lắm phải hỏi
+    lại; bỏ hợp đồng hành xử thì cùng một project, cùng một câu hỏi, lượt này tuân luật lượt
+    kia không - và người dùng không có cách nào biết vì sao, chỉ thấy Javis bướng.
+
+    GHIM FILE = NẠP NỘI DUNG. Spec ban đầu chỉ liệt kê tên và thêm chữ "(ghim)", tức là ghim
+    chỉ đổi thứ tự danh sách. Nhưng người dùng ghim bảng giá vào project thì họ nghĩ Javis đã
+    BIẾT bảng giá, chứ không phải biết TÊN nó. Nạp nội dung mới làm cái nút ghim thành công
+    tắc thật, và trần ở trên để chính họ cầm cán cân token.
+    """
+    try:
+        p = get_store().get_project_full(project_id)
+    except Exception:
+        return ""
+    if not p:
+        return ""
+    ra = ""
+    hd = (p.get("instructions") or "").strip()
+    if hd:
+        ra += (f"\n\n# === HƯỚNG DẪN RIÊNG CỦA PROJECT: {p.get('name') or ''} ===\n"
+               f"{hd[:sessions.PROJECT_INSTRUCTIONS_MAX]}")
+    if chi_huong_dan:
+        return ra
+
+    files = p.get("files") or []
+    links = p.get("links") or []
+    if not files and not links:
+        return ra
+
+    brain = p.get("brain") or "brain"
+    dong, da_nap, con_lai = [], [], PROJECT_GHIM_TONG_MAX
+    for f in files[:PROJECT_FILES_LIET_KE]:
+        ten, duong = f.get("name") or "", f.get("path") or ""
+        if not f.get("pinned"):
+            dong.append(f"- [file] {ten} - {duong}")
+            continue
+        duoi = os.path.splitext(duong)[1].lower()
+        if duoi not in PROJECT_GHIM_DUOI:
+            # Nói THẲNG là ghim nhưng không nạp được, kèm lý do. Im lặng bỏ qua thì người dùng
+            # ghim xong tưởng Javis đã đọc, rồi ngạc nhiên vì nó trả lời như chưa thấy gì.
+            dong.append(f"- [file, đã ghim nhưng là tệp nhị phân - tự mở khi cần] {ten} - {duong}")
+            continue
+        try:
+            # `_safe_serve_path` chứ không phải `_safe_path`: đây là đường ĐỌC, và trần duyệt
+            # có thể nằm CAO hơn gốc brain (vd localhost duyệt tới cả ổ đĩa). Lúc đó một đường
+            # dẫn lưu theo gốc brain sẽ không resolve được từ trần, và ngược lại - hàm serve
+            # thử cả hai quy ước, cả hai đều bị khoá trong trần. Nhánh THÊM file thì vẫn dùng
+            # `_safe_path` (chặt hơn): ở đó người dùng chọn từ trình duyệt file nên đường dẫn
+            # chắc chắn theo trần, và ghi vào kho thì phải chặt.
+            noi_dung = _safe_serve_path(brain, duong).read_text(
+                encoding="utf-8", errors="replace")
+        except Exception:
+            dong.append(f"- [file, đã ghim nhưng đọc không được] {ten} - {duong}")
+            continue
+        cat = noi_dung[:min(PROJECT_GHIM_FILE_MAX, max(0, con_lai))]
+        if not cat:
+            dong.append(f"- [file, đã ghim nhưng hết chỗ nạp trong lượt này] {ten} - {duong}")
+            continue
+        con_lai -= len(cat)
+        thieu = " (đã cắt bớt)" if len(cat) < len(noi_dung) else ""
+        da_nap.append(f"\n## {ten} - {duong}{thieu}\n{cat}")
+    for l in links[:PROJECT_FILES_LIET_KE]:
+        dong.append(f"- [link] {l.get('label') or l.get('url')} - {l.get('url')}"
+                    + (" (ghim)" if l.get("pinned") else ""))
+    if dong:
+        ra += ("\n\n# === TÀI LIỆU & LINK CỦA PROJECT ===\n"
+               "Đây là DANH SÁCH, không phải nội dung: mở file bằng tool đọc file khi cần, "
+               "đừng đoán nội dung từ cái tên. Link chỉ mở được nếu lượt này có tool duyệt web; "
+               "không có thì nói thẳng chứ đừng đoán nội dung trang.\n" + "\n".join(dong))
+    if da_nap:
+        ra += ("\n\n# === NỘI DUNG FILE ĐÃ GHIM (nạp sẵn, không cần mở lại) ===" + "".join(da_nap))
+    return ra
+
+
 def build_system_prompt(brain: str = "brain", include_memory: bool = True,
                         include_skills: bool = True,
-                        lang: "lang_mod.LangDecision | str | None" = None) -> str:
-    """CLAUDE.md + nạp MEMORY.md của vault đang chọn → Javis luôn nhớ ngữ cảnh."""
+                        lang: "lang_mod.LangDecision | str | None" = None,
+                        project_id: str = "") -> str:
+    """CLAUDE.md + nạp MEMORY.md của vault đang chọn → Javis luôn nhớ ngữ cảnh.
+
+    `project_id`: hội thoại đang nằm trong project nào. Có thì ghép thêm hướng dẫn riêng +
+    danh sách tài liệu của project đó (xem `_project_block`)."""
     base = CLAUDE_MD_PATH.read_text(encoding="utf-8") if CLAUDE_MD_PATH.exists() else ""
     # Chốt ngôn ngữ NGAY đầu hàm: khối NGÔN NGỮ ở cuối cần nó, mà danh sách skill ở giữa cũng
     # cần (mô tả skill là bề mặt ĐỐI CHIẾU với câu người dùng vừa gõ, nên nó phải cùng thứ
@@ -391,6 +491,13 @@ def build_system_prompt(brain: str = "brain", include_memory: bool = True,
         mem = ""
     if include_memory and mem.strip():
         base += "\n\n# === BỘ NHỚ DÀI HẠN (nạp sẵn) ===\n" + _fit_memory_index(mem)
+    # Ngay sau bộ nhớ, TRƯỚC lớp agentic: hướng dẫn project là luật hành xử, phải đứng cùng
+    # khu với CLAUDE.md và MEMORY.md chứ không lẫn vào khối đường dẫn kỹ thuật bên dưới.
+    if project_id:
+        try:
+            base += _project_block(project_id)
+        except Exception:
+            pass
     # Đường dẫn lớp Agentic của vault đang làm việc (để Javis tạo agent/workflow/loop qua chat)
     root = _brain_root(brain)
     system_sync.ensure_synced(root)   # brain nào cũng có đủ năng lực hệ thống (1 lần/process, rẻ)
@@ -9270,7 +9377,9 @@ async def websocket_endpoint(ws: WebSocket):
             def _legacy_system_prompt():
                 nonlocal sysprompt
                 if sysprompt is None:
-                    sysprompt = build_system_prompt(brain, lang=_lang_qd) + channel_context.build_channel_block(
+                    sysprompt = build_system_prompt(
+                        brain, lang=_lang_qd, project_id=_row0.get("project_id") or ""
+                    ) + channel_context.build_channel_block(
                         "dashboard", {"session_id": conv_sid}, telegram_running=bool(_TG_BOT),
                         port=_javis_port(), brain_root=_brain_root(brain),
                     )
@@ -9294,7 +9403,7 @@ async def websocket_endpoint(ws: WebSocket):
                 def _base(include_memory: bool, include_skills: bool) -> str:
                     return build_system_prompt(
                         brain, include_memory=include_memory, include_skills=include_skills,
-                        lang=_lang_qd,
+                        lang=_lang_qd, project_id=_row0.get("project_id") or "",
                     ) + channel_context.build_channel_block(
                         "dashboard", {"session_id": conv_sid}, telegram_running=bool(_TG_BOT),
                         port=_javis_port(), brain_root=_brain_root(brain),
@@ -12403,9 +12512,29 @@ async def _tg_answer_engine(text, meta, progress, *, chat_id, sess, brain, mcfg,
     # gói thuê bao). Đưa thêm transcript vào system prompt là gửi lịch sử HAI LẦN.
     sysprompt = ""
 
+    # Project của phiên này (Telegram cũng gán project được, nên không loại trừ kênh nào).
+    # Đọc MỘT lần: dùng cho cả nhánh Phase 8 lẫn nhánh prompt đầy đủ bên dưới.
+    _pid = ""
+    try:
+        if store is not None and conv_sid:
+            _pid = (store.get_session(conv_sid) or {}).get("project_id") or ""
+    except Exception:
+        _pid = ""
+
     def _nen_goc(include_memory: bool, include_skills: bool) -> str:
-        return build_adaptive_source_prompt(
+        # HƯỚNG DẪN project đi cả vào đường tiết kiệm; danh sách tài liệu thì không.
+        # Hướng dẫn là hợp đồng hành xử ("luôn trả lời bằng tiếng Anh"), vài trăm ký tự, và bỏ
+        # nó đi nghĩa là cùng một project cùng một câu hỏi mà lượt này tuân luật lượt kia
+        # không - người dùng không có cách nào biết vì sao, chỉ thấy Javis bướng. Danh sách
+        # tài liệu là dữ liệu tra cứu, bỏ thì cùng lắm model phải hỏi lại.
+        _n = build_adaptive_source_prompt(
             brain, include_memory=include_memory, include_skills=include_skills)
+        if _pid:
+            try:
+                _n += _project_block(_pid, chi_huong_dan=True)
+            except Exception:
+                pass
+        return _n
 
     try:
         _p8 = await asyncio.to_thread(
@@ -12422,7 +12551,7 @@ async def _tg_answer_engine(text, meta, progress, *, chat_id, sess, brain, mcfg,
     # dashboard (bản đầy đủ còn TO HƠN cái vừa bị từ chối vì quá to), nhưng ở kênh này ta chưa
     # có đường nào khác để đi, nên cứ chạy tiếp và để nhà cung cấp nói nếu thật sự quá hạn mức.
     if not sysprompt:
-        sysprompt = build_system_prompt(brain, lang=_lang_qd)
+        sysprompt = build_system_prompt(brain, lang=_lang_qd, project_id=_pid)
     sysprompt += channel_context.build_channel_block(
         channel, meta, telegram_running=(channel == "telegram"), port=_javis_port(),
         brain_root=_brain_root(brain))

--- a/tests/python/test_project_vao_prompt.py
+++ b/tests/python/test_project_vao_prompt.py
@@ -1,0 +1,160 @@
+"""Hướng dẫn và tài liệu của project phải THỰC SỰ đi vào system prompt.
+
+    python tests/run.py project_vao_prompt      (KHÔNG mạng, không spawn engine)
+
+Đợt 1 dựng kho. Đợt này là chỗ Project thôi làm cái nhãn lọc giao diện và bắt đầu đổi hành xử
+của Javis. Hai quyết định đi KHÁC spec, cả hai đều vì cùng một lý do: một tính năng nửa vời
+tệ hơn không có, vì người dùng tin là nó đang chạy.
+
+1. GHIM FILE = NẠP NỘI DUNG, không phải đổi thứ tự danh sách.
+   Spec chỉ liệt kê tên và thêm chữ "(ghim)". Nhưng người ghim bảng giá vào project thì họ
+   nghĩ Javis đã BIẾT bảng giá, chứ không phải biết TÊN nó. Ghim mà chỉ đổi thứ tự là một cái
+   nút trông như công tắc nhưng không nối vào đâu.
+
+2. HƯỚNG DẪN ĐI CẢ VÀO ĐƯỜNG TIẾT KIỆM (Phase 8), danh sách tài liệu thì không.
+   Spec bỏ cả khối khi Phase 8 rút gọn. Nhưng hướng dẫn là HỢP ĐỒNG HÀNH XỬ ("luôn trả lời
+   bằng tiếng Anh"), vài trăm ký tự; bỏ nó nghĩa là cùng một project, cùng một câu hỏi, lượt
+   này tuân luật lượt kia không - và người dùng không có cách nào biết vì sao, chỉ thấy Javis
+   bướng. Danh sách tài liệu là dữ liệu tra cứu, bỏ thì cùng lắm model phải hỏi lại.
+"""
+from _paths import ROOT, SERVER  # noqa: E402,F401
+import os
+import tempfile
+from pathlib import Path
+
+_STATE = tempfile.mkdtemp(prefix="javis-pvp-")
+os.environ.setdefault("JAVIS_STATE_DIR", _STATE)
+_BRAINS = tempfile.mkdtemp(prefix="javis-pvp-brains-")
+os.environ["BRAINS_DIR"] = _BRAINS
+
+import main  # noqa: E402
+import sessions  # noqa: E402
+
+_fails = []
+
+
+def check(ten, dieu_kien, them=""):
+    print(("ok   " if dieu_kien else "FAIL ") + ten
+          + (("  [" + str(them)[:300] + "]") if them and not dieu_kien else ""))
+    if not dieu_kien:
+        _fails.append(ten)
+
+
+st = main.get_store()
+_root = Path(main._brain_root("brain"))
+_root.mkdir(parents=True, exist_ok=True)
+
+pid = st.create_project("Mộc Việt", brain="brain")
+st.update_project(pid, instructions="Tông xanh lá. TRÁNH XANH DƯƠNG.")
+
+# File thật trong brain để ghim (đường dẫn tương đối trần duyệt, như /files/list trả ra)
+(_root / "bang-gia.md").write_text("Ghế gỗ: 1.200.000đ\nBàn trà: 2.500.000đ", encoding="utf-8")
+(_root / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"x" * 50)
+f_md = st.add_project_file(pid, "bang-gia.md")
+f_png = st.add_project_file(pid, "logo.png")
+st.add_project_link(pid, "https://elegant.vn", "Đối thủ")
+
+# ============================================================
+# 1. Hướng dẫn vào prompt
+# ============================================================
+kh = main._project_block(pid)
+check("hướng dẫn có trong khối", "TRÁNH XANH DƯƠNG" in kh, kh)
+check("kèm tên project để model biết luật này của ai", "Mộc Việt" in kh, kh)
+check("không có project thì khối rỗng", main._project_block("khong-co-that") == "")
+
+_p2 = st.create_project("Trống trơn", brain="brain")
+check("project chưa có gì thì khối rỗng", main._project_block(_p2) == "",
+      main._project_block(_p2))
+
+# ============================================================
+# 2. Chưa ghim = chỉ liệt kê tên. Ghim = NẠP NỘI DUNG
+# ============================================================
+check("file chưa ghim chỉ hiện tên + đường dẫn", "[file] bang-gia.md - bang-gia.md" in kh, kh)
+check("và nội dung file chưa ghim KHÔNG bị nạp vào", "1.200.000đ" not in kh, kh)
+
+st.set_project_file_pinned(pid, f_md, True)
+kh = main._project_block(pid)
+check("ghim rồi thì NỘI DUNG file được nạp thẳng vào prompt", "1.200.000đ" in kh, kh)
+check("có tiêu đề nói rõ đây là nội dung nạp sẵn",
+      "NỘI DUNG FILE ĐÃ GHIM" in kh, kh)
+
+# ============================================================
+# 3. Tệp nhị phân: nói THẲNG là không nạp được
+# ============================================================
+st.set_project_file_pinned(pid, f_png, True)
+kh = main._project_block(pid)
+check("ảnh ghim KHÔNG bị nhét byte nhị phân vào prompt", "\x89PNG" not in kh)
+# Im lặng bỏ qua là tệ nhất: người dùng ghim xong tưởng Javis đã đọc rồi ngạc nhiên vì nó
+# trả lời như chưa thấy gì.
+check("mà nói thẳng là tệp nhị phân, tự mở khi cần",
+      "tệp nhị phân" in kh and "logo.png" in kh, kh)
+
+# ============================================================
+# 4. Trần: một project không được nuốt hết ngân sách token
+# ============================================================
+(_root / "to.md").write_text("A" * 50000, encoding="utf-8")
+f_to = st.add_project_file(pid, "to.md")
+st.set_project_file_pinned(pid, f_to, True)
+kh = main._project_block(pid)
+check(f"file ghim to bị cắt về trần {main.PROJECT_GHIM_FILE_MAX} ký tự",
+      kh.count("A") <= main.PROJECT_GHIM_FILE_MAX + 50, kh.count("A"))
+check("và nói rõ là đã cắt bớt chứ không lặng lẽ", "đã cắt bớt" in kh, kh[-400:])
+check("tổng nội dung ghim không vượt trần chung",
+      len(kh) < main.PROJECT_GHIM_TONG_MAX + 3000, len(kh))
+
+# ============================================================
+# 5. Link: liệt kê, và DẶN model đừng đoán nội dung trang
+# ============================================================
+check("link có trong danh sách", "elegant.vn" in kh, kh)
+# Chỉ 3 engine CLI có tool duyệt web. Sáu engine API nhìn thấy URL mà không mở được, nên
+# prompt phải nói trước, không thì model bịa nội dung trang cho xong.
+check("dặn thẳng: không có tool duyệt web thì nói, đừng đoán",
+      "đừng đoán nội dung trang" in kh, kh)
+check("và dặn đừng đoán nội dung file từ cái tên",
+      "đừng đoán nội dung từ cái tên" in kh, kh)
+
+# ============================================================
+# 6. Đường tiết kiệm: giữ HƯỚNG DẪN, bỏ danh sách tài liệu
+# ============================================================
+gon = main._project_block(pid, chi_huong_dan=True)
+check("bản gọn vẫn có hướng dẫn (hợp đồng hành xử, không được rơi)",
+      "TRÁNH XANH DƯƠNG" in gon, gon)
+check("bản gọn KHÔNG kèm danh sách tài liệu", "TÀI LIỆU & LINK" not in gon, gon)
+check("và không nạp nội dung file", "1.200.000đ" not in gon, gon)
+check("nên nó nhỏ hơn hẳn bản đầy đủ", len(gon) < len(kh) / 3, (len(gon), len(kh)))
+
+# ============================================================
+# 7. Nối vào build_system_prompt
+# ============================================================
+day_du = main.build_system_prompt("brain", project_id=pid)
+check("build_system_prompt nhận project_id và ghép khối vào",
+      "TRÁNH XANH DƯƠNG" in day_du)
+khong = main.build_system_prompt("brain")
+check("không truyền project_id thì KHÔNG có khối nào (hành vi cũ nguyên vẹn)",
+      "TRÁNH XANH DƯƠNG" not in khong)
+check("project_id sai cũng không làm hỏng prompt",
+      "Javis" in main.build_system_prompt("brain", project_id="bay-gio-khong-co"))
+
+# ============================================================
+# 8. CANARY nguồn: ba chỗ gọi THẬT phải truyền project_id
+# ============================================================
+_src = (SERVER / "main.py").read_text(encoding="utf-8")
+check("CANARY: đường chat dashboard truyền project_id",
+      'lang=_lang_qd, project_id=_row0.get("project_id") or ""' in _src)
+check("CANARY: engine gói thuê bao cũng truyền",
+      'lang=_lang_qd, project_id=_row0.get("project_id") or "",' in _src)
+check("CANARY: kênh Telegram cũng truyền",
+      "build_system_prompt(brain, lang=_lang_qd, project_id=_pid)" in _src)
+# Chỗ thứ tư trong spec là hàm ƯỚC TÍNH của trang chẩn đoán (session_id "uoc-tinh" - phiên
+# giả). Nó đo prompt CHUNG chứ không đo một cuộc cụ thể, nên cố ý KHÔNG truyền project_id:
+# gắn vào là con số ước tính nhảy theo project đang mở, mà nó vốn không nói về project nào.
+check("CANARY: hàm ước tính KHÔNG gắn project (nó đo prompt chung)",
+      'return build_system_prompt(brain) + channel_context.build_channel_block(' in _src)
+check("CANARY: đường tiết kiệm chỉ lấy phần hướng dẫn",
+      "_project_block(_pid, chi_huong_dan=True)" in _src)
+
+print()
+if _fails:
+    print(f"FAIL {len(_fails)}: " + "; ".join(_fails))
+    raise SystemExit(1)
+print("TẤT CẢ PASS")


### PR DESCRIPTION
## Tóm tắt

Đợt 1 (#243) mới dựng kho và API: hướng dẫn, tài liệu, link lưu được nhưng Javis chưa đọc tới, nên Project vẫn chỉ là cái nhãn lọc giao diện. Đợt này nối phần đó vào system prompt: mở một cuộc chat thuộc project nào thì Javis nhận hướng dẫn và danh sách tài liệu của project đó ngay từ đầu lượt.

Hai chỗ đi khác spec, cùng một lý do: tính năng nửa vời tệ hơn không có, vì người dùng tin là nó đang chạy.

1. **Ghim file = nạp nội dung**, không phải đổi thứ tự danh sách. Spec chỉ liệt kê tên rồi thêm chữ "(ghim)". Người ghim bảng giá vào project thì họ nghĩ Javis đã BIẾT bảng giá chứ không phải biết TÊN nó; ghim mà chỉ đổi thứ tự là một cái nút trông như công tắc nhưng không nối vào đâu.
2. **Hướng dẫn đi cả vào đường tiết kiệm (Phase 8)**, danh sách tài liệu thì không. Spec bỏ cả khối. Nhưng hướng dẫn là hợp đồng hành xử ("luôn trả lời bằng tiếng Anh"), chỉ vài trăm ký tự; bỏ nó nghĩa là cùng một project cùng một câu hỏi mà lượt này tuân luật lượt kia không, người dùng chỉ thấy Javis bướng chứ không biết vì sao. Danh sách tài liệu là dữ liệu tra cứu, bỏ thì cùng lắm model hỏi lại.

## Thay đổi chính

- `_project_block()` dựng khối prompt: hướng dẫn project, danh sách tối đa 15 tài liệu, các link, và **nội dung file đã ghim** (trần 2000 ký tự mỗi file, 6000 tổng). Cắt thì nói rõ là đã cắt; tệp nhị phân (ảnh, xlsx) ghi thẳng là không đọc được thay vì im lặng bỏ qua.
- `build_system_prompt()` nhận thêm `project_id` và chèn khối ngay sau MEMORY.md - hướng dẫn project là luật hành xử nên đứng cùng khu với CLAUDE.md, không lẫn vào khối đường dẫn kỹ thuật bên dưới.
- Nối 3 trong 4 chỗ gọi: đường nhanh của dashboard, engine chạy nền, và Telegram. Đường tiết kiệm Phase 8 (`_nen_goc`) nhận `chi_huong_dan=True`.
- Prompt dặn thẳng hai điều model hay đoán bừa: đừng suy nội dung file từ cái tên, và link chỉ mở được nếu lượt này có tool duyệt web (chỉ 3 engine CLI có).
- Đọc file ghim bằng `_safe_serve_path` chứ không phải `_safe_path`: đây là đường ĐỌC, mà trần duyệt có thể nằm cao hơn gốc brain (localhost duyệt tới cả ổ đĩa) nên đường dẫn lưu theo gốc brain không resolve được từ trần. Nhánh THÊM file vẫn giữ `_safe_path` chặt hơn.

Một chỗ cố ý KHÔNG nối: hàm ước tính của trang chẩn đoán (phiên giả `uoc-tinh`). Nó đo prompt CHUNG chứ không đo một cuộc cụ thể, gắn project vào thì con số ước tính nhảy theo project đang mở trong khi nó không nói về project nào.

## Test

- [x] `python tests/run.py` chạy xanh - 290/290
- [x] `tests/python/test_project_vao_prompt.py` mới: khối vào đúng chỗ sau MEMORY.md, nội dung file ghim thực sự có trong prompt, trần cắt hoạt động và báo là đã cắt, tệp nhị phân được nêu tên kèm lý do, đường tiết kiệm giữ hướng dẫn và bỏ danh sách tài liệu, chat không thuộc project nào thì prompt không đổi.

## Ảnh hưởng

Chạm `server/main.py`. Cuộc chat không gắn project (mặc định) sinh ra prompt y hệt trước - khối rỗng thì không chèn gì. Chưa có giao diện nào gắn project vào chat, nên bản này người dùng chưa thấy gì khác; đợt 3 (chip + ngăn kéo Hướng dẫn/File/Link) mới lộ ra. VERSION và CHANGELOG để nguyên, gộp một lần khi đợt 3 xong.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qyB6nzw19bS3F2DMJzXgE

---
_Generated by [Claude Code](https://claude.ai/code/session_014qyB6nzw19bS3F2DMJzXgE)_