### PR TITLE
Hướng dẫn kết nối TTS Dropship trong tài liệu Kết nối

### DIFF
--- a/docs/09-mcp-va-so-lieu.md
+++ b/docs/09-mcp-va-so-lieu.md
@@ -47,6 +47,23 @@ Bên dưới, mỗi kết nối là một "đường ống" MCP (Model Context P
 
 Pancake POS mặc định ở mức **Chỉ đọc** - Javis xem được doanh thu, đơn, khách... nhưng không thể tạo đơn hay đụng tiền. Muốn Javis thao tác thật, xem mục Phân quyền bên dưới.
 
+### 1b. Kết nối TTS Dropship (token lấy từ trình duyệt)
+
+Sàn dropship.thitruongsi.com **không phát hành API key**, nên thẻ này đăng nhập bằng chính token phiên của bạn trên trình duyệt. Cài **TTS Dropship** từ tab Javis Store trước, rồi:
+
+1. Mở [dropship.thitruongsi.com](https://dropship.thitruongsi.com) và đăng nhập như bình thường.
+2. Bấm **F12** (máy Mac: Cmd + Option + I) > tab **Application** (Chrome/Edge) hoặc **Storage** (Firefox) > **Local Storage** > dòng của trang TTS.
+3. Copy toàn bộ giá trị của khoá **@publicToken** (chuỗi rất dài, bắt đầu bằng `eyJ`) rồi dán vào ô đầu tiên. Copy thêm **@refreshToken** dán vào ô thứ hai.
+4. Bấm **Kết nối**, rồi bảo Javis "kiểm tra kết nối TTS" để nó chạy `tts_health_check`.
+
+Ba điều nên biết trước khi dùng:
+
+- **Token sống khoảng 3 ngày.** Javis đọc hạn ghi ngay trên token nên báo trước khi sắp hết, và khi hết thì nói rõ phải dán lại chứ không im lặng trả số liệu sai. Ô thứ ba, "Địa chỉ gia hạn token", cứ để trống: sàn chưa công bố địa chỉ đó, điền được thì Javis mới tự gia hạn.
+- **Sàn không cho sửa đơn đã tạo.** Vì vậy tool lên đơn, huỷ đơn và đánh giá đều bắt **xác nhận hai bước**: lần gọi đầu chỉ trả bản xem trước (khách, hàng, giá, phí ship, lãi ước tính), phải xác nhận rồi Javis mới tạo thật. Đây là chốt trong mã, không phải lời nhắc.
+- **Không có đường rút tiền.** Gói chỉ đọc được biểu phí rút; muốn rút thì vào ví trên web của sàn.
+
+Mặc định ở mức **Chỉ đọc**: tìm hàng, xem đơn, tra vận đơn, xem tiền về. Muốn Javis lên đơn thay bạn thì nâng lên **Toàn quyền** trên chip tài khoản, và đọc kỹ ô cảnh báo rủi ro ở đó.
+
 ### 2. Kết nối Zalo (quét QR)
 
 Cần Node.js 20+ trên máy chạy Javis (tải tại nodejs.org, cài một lần).

--- a/docs/en/09-connections-and-business-data.md
+++ b/docs/en/09-connections-and-business-data.md
@@ -47,6 +47,23 @@ Underneath, each connection is an MCP (Model Context Protocol) pipe joining Javi
 
 Pancake POS defaults to **Read only**, so Javis can see revenue, orders and customers but cannot create orders or touch money. To let Javis act, see Permissions below.
 
+### 1b. Connecting TTS Dropship (token copied from the browser)
+
+The dropship.thitruongsi.com marketplace **issues no API keys**, so this card signs in with your own browser session token. Install **TTS Dropship** from the Javis Store tab first, then:
+
+1. Open [dropship.thitruongsi.com](https://dropship.thitruongsi.com) and log in as usual.
+2. Press **F12** (Mac: Cmd + Option + I) > the **Application** tab (Chrome/Edge) or **Storage** (Firefox) > **Local Storage** > the row for the TTS site.
+3. Copy the whole value of the **@publicToken** key (a very long string starting with `eyJ`) into the first field. Copy **@refreshToken** into the second one.
+4. Click **Connect**, then ask Javis to "check the TTS connection" so it runs `tts_health_check`.
+
+Three things worth knowing up front:
+
+- **The token lives about 3 days.** Javis reads the expiry stamped inside the token, so it warns you before it runs out and says plainly what to do once it has, rather than quietly returning wrong numbers. Leave the third field, "Token refresh URL", empty: the marketplace has not published that address, and Javis only auto-refreshes once you can fill it in.
+- **The marketplace does not allow editing an order once created.** So the order, cancel and rating tools all require **two-step confirmation**: the first call returns a preview only (customer, items, price, shipping, estimated profit), and Javis creates the real order only after you confirm. That gate is in the code, not just a reminder.
+- **There is no withdrawal tool.** The pack can read the withdrawal fee schedule and nothing more; to withdraw, use the wallet on the marketplace's own site.
+
+It defaults to **Read only**: finding products, reading orders, tracking shipments, checking incoming money. To let Javis place orders for you, raise the account chip to **Full access** and read the risk warning shown there.
+
 ### 2. Connecting Zalo (QR scan)
 
 Requires Node.js 20+ on the machine running Javis (download from nodejs.org, install once).


### PR DESCRIPTION
## Tóm tắt

Kho vừa có thêm gói kết nối **TTS Dropship** ([javis-store#7](https://github.com/blogminhquy/javis-store/pull/7)), và thẻ này đăng nhập khác mọi thẻ còn lại: sàn dropship.thitruongsi.com **không phát hành API key**, nên người dùng phải tự mở F12 và copy token phiên trong Local Storage của trình duyệt.

Đó là bước không ai đoán ra được. Ô hướng dẫn trên thẻ có nói, nhưng tài liệu Kết nối là chỗ người ta đọc trước khi bấm, và nó đang dạy tay từng dịch vụ một (Pancake POS, Zalo, Shopify, bộ Google, quảng cáo...). Thiếu TTS ở đó là một lỗ đúng chỗ khó nhất.

PR này **chỉ sửa tài liệu, không đụng một dòng mã nào**.

## Thay đổi chính

- Thêm mục **1b. Kết nối TTS Dropship (token lấy từ trình duyệt)** vào `docs/09-mcp-va-so-lieu.md`, đặt ngay sau Pancake POS vì cùng nhóm Bán hàng.
- Thêm mục tương ứng vào bản tiếng Anh `docs/en/09-connections-and-business-data.md`, giữ đúng cấu trúc song ngữ hiện có.
- Ngoài 4 bước lấy token, mục này nói trước **ba điều người dùng chắc chắn sẽ đụng phải**, mỗi điều một câu:
  1. Token sống khoảng 3 ngày. Javis đọc hạn ghi sẵn trong token nên báo trước, và ô "Địa chỉ gia hạn token" cứ để trống vì sàn chưa công bố địa chỉ đó.
  2. Sàn không cho sửa đơn đã tạo, nên tool lên đơn / huỷ đơn / đánh giá bắt **xác nhận hai bước**, và đó là chốt trong mã chứ không phải lời nhắc.
  3. Gói **không có đường rút tiền**, chỉ đọc được biểu phí.
- Mặc định mức Chỉ đọc, và có chỉ dẫn sang mục Phân quyền cho ai muốn Javis lên đơn thay mình.

## Test

- [x] `python tests/run.py` chạy xanh
- [x] CI trên nhánh này xanh: [run #1007](https://github.com/blogminhquy/javis-os/actions/runs/33943265713) (`claude/**` nên `push` kích hoạt CI trước khi mở PR)
- [x] Không có ký tự em dash trong phần thêm mới (luật của chủ repo)
- [x] Bản tiếng Việt và bản tiếng Anh nói cùng một nội dung, cùng vị trí trong mục lục

Ghi chú về môi trường phiên này: chạy `tests/run.py` tại chỗ chỉ được 205/317 vì sandbox thiếu và xung đột dependency (`fastapi`/`pydantic`, `dotenv`, `PyJWT` cài bằng apt không gỡ được). Mọi test đỏ đều dừng ở `ModuleNotFoundError` lúc import, không phải ở assertion. CI với môi trường sạch chạy đủ **317/317 xanh**, và đó mới là con số đáng tin ở đây.

## Ảnh hưởng

Hai file `.md` trong `docs/`. Không đụng `server/`, `dashboard/`, `system/`, không đổi hành vi app, không có rủi ro phá tính năng khác.

Gói thật nằm ở repo kho: [blogminhquy/javis-store#7](https://github.com/blogminhquy/javis-store/pull/7). Hai PR này độc lập nhau, trộn cái nào trước cũng được. Trộn PR tài liệu này trước khi gói lên kho thì trong khoảng thời gian đó tài liệu nhắc tới một thẻ chưa tìm thấy trong tab Javis Store, nên nếu chọn thứ tự thì trộn bên kho trước sẽ gọn hơn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoG2ioGu8ZCNjCafPonXoH

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoG2ioGu8ZCNjCafPonXoH)_